### PR TITLE
Compare target modes in model experiment report

### DIFF
--- a/src/trading_lab/models/experiment_report.py
+++ b/src/trading_lab/models/experiment_report.py
@@ -3,19 +3,22 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
+from sklearn.metrics import brier_score_loss
 
-from trading_lab.config import TradingConfig, load_trading_config
-from trading_lab.config.targets import PredictionTarget
+from trading_lab.backtests.walk_forward import _event_returns, _summarize
+from trading_lab.config import TradingColumns, TradingConfig, load_trading_config
+from trading_lab.config.targets import PredictionTarget, default_prediction_targets
+from trading_lab.features.targets import add_prediction_target
 from trading_lab.models.baseline import BASELINE_PATH
 from trading_lab.models.dataset import (
     FEATURE_PATH,
     load_market_features,
-    primary_prediction_target,
     supervised_frame,
     target_column,
+    walk_forward_folds,
 )
 from trading_lab.models.quality import OUT_PATH as QUALITY_PATH
-from trading_lab.models.zoo import REPORT_DIR
+from trading_lab.models.zoo import REPORT_DIR, ModelConfig, ModelFactory, default_configs, safe_roc_auc
 
 
 CSV_PATH = REPORT_DIR / "model_experiment_report.csv"
@@ -37,9 +40,13 @@ REPORT_FIELDS = [
     "mean_profit_factor",
     "worst_fold_return",
     "worst_fold_drawdown",
+    "score",
     "model_quality_status",
     "baseline_status",
 ]
+
+
+TARGET_MODES = ["barrier_first_hit", "horizon_return", "threshold_horizon_return"]
 
 
 def _read_status_line(path: Path, prefix: str) -> str | None:
@@ -55,6 +62,196 @@ def _baseline_status(path: Path = BASELINE_PATH) -> str:
     return "BASELINE_AVAILABLE" if path.exists() else "NO_BASELINE"
 
 
+def _target_variants(base_targets: list[PredictionTarget]) -> list[PredictionTarget]:
+    variants: list[PredictionTarget] = []
+    for base in base_targets:
+        for mode in TARGET_MODES:
+            variants.append(
+                PredictionTarget(
+                    name=f"{base.name}_{mode}",
+                    symbol=base.symbol,
+                    horizon_days=base.horizon_days,
+                    up_threshold=base.up_threshold,
+                    down_threshold=base.down_threshold,
+                    mode=mode,
+                )
+            )
+    return variants
+
+
+def _ensure_target_column(df: pd.DataFrame, target: PredictionTarget) -> pd.DataFrame:
+    col = target_column(target)
+    if col in df.columns:
+        return df
+    return add_prediction_target(df, target)
+
+
+def _model_configs(model_zoo_path: Path) -> list[ModelConfig]:
+    if not model_zoo_path.exists():
+        return default_configs()
+
+    zoo = pd.read_csv(model_zoo_path)
+    if zoo.empty or "model" not in zoo.columns:
+        return default_configs()
+
+    configs: list[ModelConfig] = []
+    for _, row in zoo.drop_duplicates(subset=["model"]).iterrows():
+        defaults = ModelConfig(str(row["model"]))
+        configs.append(
+            ModelConfig(
+                name=str(row["model"]),
+                threshold=float(row.get("threshold", defaults.threshold)),
+                take_profit=float(row.get("take_profit", defaults.take_profit)),
+                stop_loss=float(row.get("stop_loss", defaults.stop_loss)),
+                max_hold=int(row.get("max_hold", defaults.max_hold)),
+                require_trend=bool(row.get("require_trend", defaults.require_trend)),
+                max_ext20=(
+                    None
+                    if pd.isna(row.get("max_ext20", None))
+                    else float(row.get("max_ext20", defaults.max_ext20))
+                ),
+            )
+        )
+    return configs or default_configs()
+
+
+def _score_summary(row: dict) -> float:
+    auc = row.get("mean_roc_auc")
+    profit_factor = row.get("mean_profit_factor")
+    drawdown = row.get("worst_fold_drawdown")
+    brier = row.get("mean_brier")
+
+    auc_score = 0.0 if pd.isna(auc) else float(auc)
+    if pd.isna(profit_factor) or profit_factor == float("inf"):
+        pf_score = 0.0
+    else:
+        pf_score = min(float(profit_factor), 10.0) / 10.0
+    dd_score = 0.0 if pd.isna(drawdown) else float(drawdown)
+    brier_penalty = 0.0 if pd.isna(brier) else float(brier)
+    return auc_score + pf_score + dd_score - brier_penalty
+
+
+def rank_model_experiment_report(report: pd.DataFrame) -> pd.DataFrame:
+    if report.empty:
+        return report
+
+    ranked = report.copy()
+    pf = pd.to_numeric(ranked["mean_profit_factor"], errors="coerce")
+    ranked["_finite_profit_factor"] = pf.notna() & (~pf.isin([float("inf"), float("-inf")]))
+    ranked["_roc_auc_sort"] = pd.to_numeric(ranked["mean_roc_auc"], errors="coerce").fillna(-1.0)
+    ranked["_profit_factor_sort"] = pf.where(ranked["_finite_profit_factor"], -1.0).fillna(-1.0)
+    ranked["_drawdown_sort"] = pd.to_numeric(ranked["worst_fold_drawdown"], errors="coerce").fillna(-1.0)
+    ranked = ranked.sort_values(
+        [
+            "_finite_profit_factor",
+            "_roc_auc_sort",
+            "_profit_factor_sort",
+            "_drawdown_sort",
+        ],
+        ascending=[False, False, False, False],
+    )
+    return ranked.drop(
+        columns=[
+            "_finite_profit_factor",
+            "_roc_auc_sort",
+            "_profit_factor_sort",
+            "_drawdown_sort",
+        ]
+    ).reset_index(drop=True)
+
+
+def _evaluate_candidate(
+    supervised: pd.DataFrame,
+    feature_cols: list[str],
+    model_config: ModelConfig,
+    config: TradingConfig,
+) -> dict:
+    fold_rows: list[dict] = []
+    trade_rows: list[dict] = []
+
+    for train, test in walk_forward_folds(supervised, n_folds=4):
+        if len(train) < 2 or len(test) < 1 or train["target"].nunique() < 2:
+            continue
+
+        model = ModelFactory.build(model_config.name)
+        model.fit(train[feature_cols], train["target"])
+        proba = model.predict_proba(test[feature_cols])[:, 1]
+
+        fold_rows.append(
+            {
+                "train_rows": len(train),
+                "test_rows": len(test),
+                "positive_rate": float(train["target"].mean()),
+                "mean_roc_auc": safe_roc_auc(test["target"], proba),
+                "mean_brier": float(brier_score_loss(test["target"], proba)),
+            }
+        )
+
+        scored = test.copy()
+        scored["proba"] = proba
+        if _has_trade_columns(scored, config):
+            trades = _event_returns(
+                df=scored,
+                prob_col="proba",
+                threshold=model_config.threshold,
+                take_profit=model_config.take_profit,
+                stop_loss=model_config.stop_loss,
+                max_hold=model_config.max_hold,
+                require_trend=model_config.require_trend,
+                max_ext20=model_config.max_ext20,
+                config=config,
+            )
+            trade_rows.append(_summarize(trades))
+
+    if not fold_rows:
+        return {
+            "train_rows": len(supervised),
+            "test_rows": 0,
+            "positive_rate": float(supervised["target"].mean()) if len(supervised) else None,
+            "mean_roc_auc": None,
+            "mean_brier": None,
+            "mean_win_rate": None,
+            "mean_profit_factor": None,
+            "worst_fold_return": None,
+            "worst_fold_drawdown": None,
+        }
+
+    folds = pd.DataFrame(fold_rows)
+    trades = pd.DataFrame(trade_rows)
+    result = {
+        "train_rows": int(folds["train_rows"].max()),
+        "test_rows": int(folds["test_rows"].sum()),
+        "positive_rate": float(folds["positive_rate"].mean()),
+        "mean_roc_auc": float(folds["mean_roc_auc"].mean()),
+        "mean_brier": float(folds["mean_brier"].mean()),
+        "mean_win_rate": None,
+        "mean_profit_factor": None,
+        "worst_fold_return": None,
+        "worst_fold_drawdown": None,
+    }
+    if not trades.empty:
+        result.update(
+            {
+                "mean_win_rate": float(trades["win_rate"].mean()),
+                "mean_profit_factor": float(trades["profit_factor"].mean()),
+                "worst_fold_return": float(trades["total_return"].min()),
+                "worst_fold_drawdown": float(trades["max_drawdown"].min()),
+            }
+        )
+    return result
+
+
+def _has_trade_columns(df: pd.DataFrame, config: TradingConfig) -> bool:
+    cols = TradingColumns(config)
+    required = [
+        "date",
+        cols.traded_price,
+        cols.benchmark_uptrend,
+        cols.benchmark_dist_ma_20,
+    ]
+    return all(col in df.columns for col in required)
+
+
 def build_model_experiment_report(
     model_zoo_path: Path = MODEL_ZOO_PATH,
     feature_path: Path = FEATURE_PATH,
@@ -62,54 +259,52 @@ def build_model_experiment_report(
     config: TradingConfig | None = None,
 ) -> pd.DataFrame:
     cfg = config or load_trading_config()
-    selected_target = target or primary_prediction_target(cfg)
-    target_col = target_column(selected_target)
-
-    if not model_zoo_path.exists():
+    if not feature_path.exists():
         return pd.DataFrame(columns=REPORT_FIELDS)
 
-    zoo = pd.read_csv(model_zoo_path)
-    if zoo.empty:
-        return pd.DataFrame(columns=REPORT_FIELDS)
-
-    train_rows = None
-    positive_rate = None
-    if feature_path.exists():
-        features = load_market_features(feature_path)
-        try:
-            supervised, _, _ = supervised_frame(features, target=selected_target, config=cfg)
-            train_rows = len(supervised)
-            positive_rate = float(supervised["target"].mean())
-        except ValueError:
-            train_rows = None
-            positive_rate = None
-
+    features = load_market_features(feature_path)
+    base_targets = [target] if target is not None else default_prediction_targets(cfg)
+    targets = _target_variants(base_targets)
+    model_configs = _model_configs(model_zoo_path)
     quality_status = _read_status_line(QUALITY_PATH, "status:") or ""
     baseline_status = _baseline_status()
 
     rows = []
-    for _, row in zoo.iterrows():
-        rows.append(
-            {
-                "target_name": selected_target.name,
-                "target_mode": selected_target.mode,
+    for candidate_target in targets:
+        features = _ensure_target_column(features, candidate_target)
+        target_col = target_column(candidate_target)
+        try:
+            supervised, feature_cols, _ = supervised_frame(features, target=candidate_target, config=cfg)
+        except ValueError:
+            continue
+
+        extra_cols = [
+            col
+            for col in [
+                TradingColumns(cfg).traded_price,
+                TradingColumns(cfg).benchmark_uptrend,
+                TradingColumns(cfg).benchmark_dist_ma_20,
+            ]
+            if col in features.columns and col not in supervised.columns
+        ]
+        if extra_cols:
+            supervised = supervised.merge(features[["date"] + extra_cols], on="date", how="left")
+
+        for model_config in model_configs:
+            metrics = _evaluate_candidate(supervised, feature_cols, model_config, cfg)
+            row = {
+                "target_name": candidate_target.name,
+                "target_mode": candidate_target.mode,
                 "target_col": target_col,
-                "model": row.get("model"),
-                "train_rows": train_rows,
-                "test_rows": row.get("test_rows"),
-                "positive_rate": positive_rate,
-                "mean_roc_auc": row.get("mean_roc_auc", row.get("roc_auc")),
-                "mean_brier": row.get("mean_brier"),
-                "mean_win_rate": row.get("mean_win_rate"),
-                "mean_profit_factor": row.get("mean_profit_factor"),
-                "worst_fold_return": row.get("worst_fold_return"),
-                "worst_fold_drawdown": row.get("worst_fold_drawdown"),
+                "model": model_config.name,
+                **metrics,
                 "model_quality_status": quality_status,
                 "baseline_status": baseline_status,
             }
-        )
+            row["score"] = _score_summary(row)
+            rows.append(row)
 
-    return pd.DataFrame(rows, columns=REPORT_FIELDS)
+    return rank_model_experiment_report(pd.DataFrame(rows, columns=REPORT_FIELDS))
 
 
 def write_model_experiment_report(
@@ -140,9 +335,27 @@ def format_model_experiment_markdown(report: pd.DataFrame) -> str:
         "mean_brier",
         "mean_profit_factor",
         "worst_fold_drawdown",
+        "score",
         "model_quality_status",
         "baseline_status",
     ]
+    best = report.iloc[0]
+    lines.extend(
+        [
+            "## Best Candidate",
+            "",
+            f"- target_name: {best['target_name']}",
+            f"- target_mode: {best['target_mode']}",
+            f"- model: {best['model']}",
+            f"- mean_roc_auc: {best['mean_roc_auc']}",
+            f"- mean_profit_factor: {best['mean_profit_factor']}",
+            f"- worst_fold_drawdown: {best['worst_fold_drawdown']}",
+            f"- score: {best['score']}",
+            "",
+            "## Ranked Candidates",
+            "",
+        ]
+    )
     display = report[cols].fillna("")
     lines.append("| " + " | ".join(cols) + " |")
     lines.append("| " + " | ".join(["---"] * len(cols)) + " |")

--- a/tests/test_model_experiment_report.py
+++ b/tests/test_model_experiment_report.py
@@ -3,59 +3,173 @@ from pathlib import Path
 import pandas as pd
 
 from trading_lab.config import TradingConfig
-from trading_lab.models.experiment_report import build_model_experiment_report, write_model_experiment_report
+from trading_lab.models.experiment_report import (
+    build_model_experiment_report,
+    rank_model_experiment_report,
+    write_model_experiment_report,
+)
 
 
-def test_model_experiment_report_consolidates_zoo_and_target_metadata(tmp_path: Path):
+def _write_model_zoo(path: Path) -> None:
+    pd.DataFrame(
+        [
+            {
+                "model": "logistic_regression",
+                "threshold": 0.50,
+                "take_profit": 0.05,
+                "stop_loss": 0.05,
+                "max_hold": 3,
+                "require_trend": True,
+                "max_ext20": 0.04,
+            }
+        ]
+    ).to_csv(path, index=False)
+
+
+def _write_features(path: Path, include_only_barrier: bool = False) -> None:
+    prices = [
+        100,
+        108,
+        96,
+        111,
+        93,
+        115,
+        95,
+        118,
+        97,
+        121,
+        99,
+        124,
+        101,
+        127,
+        103,
+        130,
+        104,
+        128,
+        106,
+        132,
+        108,
+        134,
+        110,
+        136,
+        112,
+        138,
+        114,
+        140,
+        116,
+        142,
+    ]
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=len(prices)),
+            "SOXL": prices,
+            "SOXL_ret_1d": pd.Series(prices).pct_change().fillna(0.0),
+            "SOXL_dist_ma_20": [0.01] * len(prices),
+            "SOXL_vol_5d": [0.2] * len(prices),
+            "SOXL_drawdown_from_20d_high": [-0.01] * len(prices),
+            "XLK_ret_1d": [0.01, -0.01] * 15,
+            "XLK_dist_ma_20": [0.01] * len(prices),
+            "XLK_uptrend_20_50": [True] * len(prices),
+            "SPY_ret_1d": [0.005, -0.005] * 15,
+        }
+    )
+    if include_only_barrier:
+        df["SOXL_hit_up_before_down_5d"] = ([1, 0] * 15)
+    df.to_csv(path, index=False)
+
+
+def test_model_experiment_report_includes_all_target_modes(tmp_path: Path):
+    zoo_path = tmp_path / "model_zoo_ranking.csv"
+    feature_path = tmp_path / "market_features.csv"
+    _write_model_zoo(zoo_path)
+    _write_features(feature_path)
+
+    report = build_model_experiment_report(
+        model_zoo_path=zoo_path,
+        feature_path=feature_path,
+        config=TradingConfig(traded_symbol="SOXL", benchmark_symbol="XLK"),
+    )
+
+    assert set(report["target_mode"]) == {
+        "barrier_first_hit",
+        "horizon_return",
+        "threshold_horizon_return",
+    }
+    assert set(report["model"]) == {"logistic_regression"}
+
+
+def test_model_experiment_report_generates_missing_target_columns(tmp_path: Path):
+    zoo_path = tmp_path / "model_zoo_ranking.csv"
+    feature_path = tmp_path / "market_features.csv"
+    _write_model_zoo(zoo_path)
+    _write_features(feature_path, include_only_barrier=True)
+
+    report = build_model_experiment_report(
+        model_zoo_path=zoo_path,
+        feature_path=feature_path,
+        config=TradingConfig(traded_symbol="SOXL", benchmark_symbol="XLK"),
+    )
+
+    assert "SOXL_horizon_return_5d" in set(report["target_col"])
+    assert "SOXL_threshold_horizon_return_up5pct_5d" in set(report["target_col"])
+    assert report["train_rows"].notna().all()
+
+
+def test_model_experiment_report_sorts_candidates():
+    report = pd.DataFrame(
+        [
+            {
+                "target_name": "a",
+                "target_mode": "barrier_first_hit",
+                "target_col": "a",
+                "model": "bad_inf",
+                "mean_roc_auc": 0.99,
+                "mean_profit_factor": float("inf"),
+                "worst_fold_drawdown": -0.01,
+            },
+            {
+                "target_name": "b",
+                "target_mode": "horizon_return",
+                "target_col": "b",
+                "model": "best_finite",
+                "mean_roc_auc": 0.70,
+                "mean_profit_factor": 2.0,
+                "worst_fold_drawdown": -0.05,
+            },
+            {
+                "target_name": "c",
+                "target_mode": "threshold_horizon_return",
+                "target_col": "c",
+                "model": "lower_auc",
+                "mean_roc_auc": 0.60,
+                "mean_profit_factor": 3.0,
+                "worst_fold_drawdown": -0.02,
+            },
+        ]
+    )
+
+    ranked = rank_model_experiment_report(report)
+
+    assert ranked.iloc[0]["model"] == "best_finite"
+    assert ranked.iloc[-1]["model"] == "bad_inf"
+
+
+def test_write_model_experiment_report_outputs_best_candidate_section(tmp_path: Path):
     zoo_path = tmp_path / "model_zoo_ranking.csv"
     feature_path = tmp_path / "market_features.csv"
     csv_path = tmp_path / "report.csv"
     md_path = tmp_path / "report.md"
-
-    pd.DataFrame(
-        [
-            {
-                "model": "random_forest",
-                "test_rows": 12,
-                "mean_roc_auc": 0.61,
-                "mean_brier": 0.22,
-                "mean_win_rate": 0.55,
-                "mean_profit_factor": 1.8,
-                "worst_fold_return": -0.02,
-                "worst_fold_drawdown": -0.08,
-            }
-        ]
-    ).to_csv(zoo_path, index=False)
-    pd.DataFrame(
-        {
-            "date": pd.date_range("2024-01-01", periods=4),
-            "SOXL_ret_1d": [0.01, 0.02, 0.03, 0.04],
-            "XLK_ret_1d": [0.01, 0.02, 0.03, 0.04],
-            "SPY_ret_1d": [0.01, 0.02, 0.03, 0.04],
-            "XLK_uptrend_20_50": [True, True, False, True],
-            "SOXL_hit_up_before_down_5d": [1, 0, 1, 0],
-        }
-    ).to_csv(feature_path, index=False)
-
-    config = TradingConfig(traded_symbol="SOXL", benchmark_symbol="XLK")
-    report = build_model_experiment_report(
-        model_zoo_path=zoo_path,
-        feature_path=feature_path,
-        config=config,
-    )
-
-    assert report.loc[0, "target_mode"] == "barrier_first_hit"
-    assert report.loc[0, "target_col"] == "SOXL_hit_up_before_down_5d"
-    assert report.loc[0, "positive_rate"] == 0.5
+    _write_model_zoo(zoo_path)
+    _write_features(feature_path)
 
     written = write_model_experiment_report(
         csv_path=csv_path,
         md_path=md_path,
         model_zoo_path=zoo_path,
         feature_path=feature_path,
-        config=config,
+        config=TradingConfig(traded_symbol="SOXL", benchmark_symbol="XLK"),
     )
 
-    assert len(written) == 1
+    assert len(written) == 6
     assert csv_path.exists()
-    assert "random_forest" in md_path.read_text(encoding="utf-8")
+    assert "## Best Candidate" in md_path.read_text(encoding="utf-8")


### PR DESCRIPTION
Expands the model experiment report to evaluate barrier-first-hit, horizon-return, and threshold-horizon-return target modes. Adds ranking and synthetic tests. Advances issues #2 and #4.