### PR TITLE
Add optional experiment-selected target mode

### DIFF
--- a/scripts/select_target.py
+++ b/scripts/select_target.py
@@ -1,0 +1,5 @@
+from trading_lab.models.target_selection import main
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trading_lab/config/settings.py
+++ b/src/trading_lab/config/settings.py
@@ -18,6 +18,9 @@ class TradingConfig:
     account_value: float = 5000.0
     max_traded_allocation_wait: float = 0.05
     max_core_allocation_wait: float = 0.50
+    use_experiment_selected_target: bool = False
+    selected_target_mode: str | None = None
+    selected_target_name: str | None = None
 
     @property
     def traded_upper(self) -> str:
@@ -36,6 +39,7 @@ def load_trading_config(path: Path = DEFAULT_CONFIG_PATH) -> TradingConfig:
     symbols = data.get("symbols", {})
     account = data.get("account", {})
     allocation = data.get("allocation", {})
+    modeling = data.get("modeling", {})
 
     return TradingConfig(
         traded_symbol=str(symbols.get("traded", TradingConfig.traded_symbol)),
@@ -49,4 +53,12 @@ def load_trading_config(path: Path = DEFAULT_CONFIG_PATH) -> TradingConfig:
         max_core_allocation_wait=float(
             allocation.get("max_core_allocation_wait", TradingConfig.max_core_allocation_wait)
         ),
+        use_experiment_selected_target=bool(
+            modeling.get(
+                "use_experiment_selected_target",
+                TradingConfig.use_experiment_selected_target,
+            )
+        ),
+        selected_target_mode=modeling.get("selected_target_mode"),
+        selected_target_name=modeling.get("selected_target_name"),
     )

--- a/src/trading_lab/dashboard/daily.py
+++ b/src/trading_lab/dashboard/daily.py
@@ -70,6 +70,10 @@ def build_daily_decision_summary() -> str:
     baseline_prob = float(baseline_pred["random_forest_proba"])
     selected_model_prob = float(selected_pred["probability"])
     selected_model_name = str(selected_pred["model"])
+    configured_target_mode = str(selected_pred.get("configured_target_mode", "barrier_first_hit"))
+    active_target_mode = str(selected_pred.get("active_target_mode", configured_target_mode))
+    active_target_col = str(selected_pred.get("active_target_col", cols.traded_target(5)))
+    target_source = str(selected_pred.get("target_source", "default_config"))
 
     allocation = recommend_allocation(
         rf_probability=selected_model_prob,
@@ -91,6 +95,10 @@ def build_daily_decision_summary() -> str:
         f"{cfg.traded_symbol}: {traded_price:.2f}",
         f"RF probability: {baseline_prob:.3f}",
         f"Selected model probability ({selected_model_name}): {selected_model_prob:.3f}",
+        f"Configured target mode: {configured_target_mode}",
+        f"Active target mode: {active_target_mode}",
+        f"Active target column: {active_target_col}",
+        f"Target source: {target_source}",
         f"{cfg.benchmark_symbol} uptrend 20/50: {trend}",
         f"{cfg.benchmark_symbol} distance from 20DMA: {_fmt_pct(benchmark_ext20)}",
         f"{cfg.benchmark_symbol} distance from 50DMA: {_fmt_pct(benchmark_ext50)}",

--- a/src/trading_lab/models/dataset.py
+++ b/src/trading_lab/models/dataset.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from trading_lab.config import TradingColumns, TradingConfig, load_trading_config
 from trading_lab.config.targets import PredictionTarget, default_prediction_targets
+from trading_lab.features.targets import add_prediction_target
 from trading_lab.features.targets import target_column as feature_target_column
 
 
@@ -66,6 +67,12 @@ def target_column(target: PredictionTarget) -> str:
     return feature_target_column(target)
 
 
+def ensure_target_column(df: pd.DataFrame, target: PredictionTarget) -> pd.DataFrame:
+    if target_column(target) in df.columns:
+        return df
+    return add_prediction_target(df, target)
+
+
 def supervised_frame(
     df: pd.DataFrame,
     target: PredictionTarget | None = None,
@@ -73,6 +80,7 @@ def supervised_frame(
 ) -> tuple[pd.DataFrame, list[str], str]:
     cfg = _config(config)
     selected_target = target or primary_prediction_target(cfg)
+    df = ensure_target_column(df, selected_target)
     target_col = target_column(selected_target)
     features = feature_columns(df, cfg)
 

--- a/src/trading_lab/models/live.py
+++ b/src/trading_lab/models/live.py
@@ -4,8 +4,15 @@ from pathlib import Path
 
 import pandas as pd
 
-from trading_lab.models.dataset import latest_feature_row, load_market_features, supervised_frame
+from trading_lab.config import TradingConfig, load_trading_config
+from trading_lab.models.dataset import (
+    latest_feature_row,
+    load_market_features,
+    primary_prediction_target,
+    supervised_frame,
+)
 from trading_lab.models.selection import select_model_zoo_winner
+from trading_lab.models.target_selection import SelectedTarget, selected_prediction_target
 from trading_lab.models.zoo import ModelFactory
 
 
@@ -16,13 +23,19 @@ OUT_PATH = Path("data/reports/selected_model_latest_signal.csv")
 def score_selected_model_latest(
     feature_path: Path = FEATURE_PATH,
     out_path: Path = OUT_PATH,
+    config: TradingConfig | None = None,
+    selected_target: SelectedTarget | None = None,
 ) -> pd.DataFrame:
+    cfg = config or load_trading_config()
     df = load_market_features(feature_path)
     selected = select_model_zoo_winner()
-    train, feature_cols, _ = supervised_frame(df)
-    latest, _ = latest_feature_row(df)
+    target_selection = selected_target or selected_prediction_target(cfg)
+    train, feature_cols, target_col = supervised_frame(df, target=target_selection.target, config=cfg)
+    latest, _ = latest_feature_row(df, cfg)
 
-    model = ModelFactory.build(selected.model)
+    active_model = target_selection.model if target_selection.source == "experiment_report" else selected.model
+    active_model = active_model or selected.model
+    model = ModelFactory.build(active_model)
     model.fit(train[feature_cols], train["target"])
 
     probability = float(model.predict_proba(latest[feature_cols])[:, 1][0])
@@ -31,12 +44,16 @@ def score_selected_model_latest(
         [
             {
                 "date": latest["date"].iloc[0],
-                "model": selected.model,
+                "model": active_model,
                 "probability": probability,
                 "train_rows": len(train),
                 "target_positive_rate": float(train["target"].mean()),
                 "selected_model_profit_factor": selected.mean_profit_factor,
                 "selected_model_worst_drawdown": selected.worst_fold_drawdown,
+                "configured_target_mode": primary_prediction_target(cfg).mode,
+                "active_target_mode": target_selection.target_mode,
+                "active_target_col": target_col,
+                "target_source": target_selection.source,
             }
         ]
     )

--- a/src/trading_lab/models/target_selection.py
+++ b/src/trading_lab/models/target_selection.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from trading_lab.config import TradingConfig, load_trading_config
+from trading_lab.config.targets import PredictionTarget, default_prediction_targets
+from trading_lab.models.dataset import primary_prediction_target, target_column
+
+
+CSV_PATH = Path("data/reports/model_experiment_report.csv")
+
+@dataclass(frozen=True)
+class SelectedTarget:
+    target: PredictionTarget
+    target_name: str
+    target_mode: str
+    target_col: str
+    model: str | None
+    mean_roc_auc: float | None
+    mean_profit_factor: float | None
+    worst_fold_drawdown: float | None
+    score: float | None
+    source: str
+    fallback_reason: str | None = None
+
+
+def load_experiment_report(path: Path = CSV_PATH) -> pd.DataFrame:
+    if not path.exists():
+        return pd.DataFrame()
+    return pd.read_csv(path)
+
+
+def select_best_target(report_df: pd.DataFrame) -> pd.Series | None:
+    if report_df.empty:
+        return None
+
+    required = {"target_name", "target_mode", "target_col"}
+    if not required.issubset(report_df.columns):
+        return None
+
+    ranked = report_df.copy()
+    pf = pd.to_numeric(ranked.get("mean_profit_factor"), errors="coerce")
+    ranked["_finite_profit_factor"] = pf.notna() & (~pf.isin([float("inf"), float("-inf")]))
+    ranked["_roc_auc_sort"] = pd.to_numeric(ranked.get("mean_roc_auc"), errors="coerce").fillna(-1.0)
+    ranked["_score_sort"] = pd.to_numeric(ranked.get("score"), errors="coerce").fillna(-1.0)
+    ranked["_profit_factor_sort"] = pf.where(ranked["_finite_profit_factor"], -1.0).fillna(-1.0)
+    ranked["_drawdown_sort"] = pd.to_numeric(ranked.get("worst_fold_drawdown"), errors="coerce").fillna(-1.0)
+    ranked = ranked.sort_values(
+        [
+            "_finite_profit_factor",
+            "_roc_auc_sort",
+            "_score_sort",
+            "_profit_factor_sort",
+            "_drawdown_sort",
+        ],
+        ascending=[False, False, False, False, False],
+    )
+    return ranked.iloc[0]
+
+
+def selected_prediction_target(
+    config: TradingConfig | None = None,
+    report_df: pd.DataFrame | None = None,
+) -> SelectedTarget:
+    cfg = config or load_trading_config()
+    default_target = primary_prediction_target(cfg)
+    if not cfg.use_experiment_selected_target:
+        return _default_selection(default_target, "experiment target selection disabled")
+
+    report = report_df if report_df is not None else load_experiment_report()
+    if report.empty:
+        return _default_selection(default_target, "experiment report missing or empty")
+
+    filtered = _filter_report(report, cfg)
+    row = select_best_target(filtered)
+    if row is None:
+        return _default_selection(default_target, "experiment report has no valid target rows")
+
+    target = _target_from_row(cfg, row)
+    if target is None:
+        return _default_selection(default_target, "selected target does not match configured targets")
+
+    return SelectedTarget(
+        target=target,
+        target_name=str(row["target_name"]),
+        target_mode=str(row["target_mode"]),
+        target_col=str(row["target_col"]),
+        model=str(row["model"]) if "model" in row and pd.notna(row["model"]) else None,
+        mean_roc_auc=_optional_float(row, "mean_roc_auc"),
+        mean_profit_factor=_optional_float(row, "mean_profit_factor"),
+        worst_fold_drawdown=_optional_float(row, "worst_fold_drawdown"),
+        score=_optional_float(row, "score"),
+        source="experiment_report",
+    )
+
+
+def _filter_report(report: pd.DataFrame, config: TradingConfig) -> pd.DataFrame:
+    out = report.copy()
+    if config.selected_target_mode and "target_mode" in out.columns:
+        out = out[out["target_mode"].astype(str).eq(config.selected_target_mode)]
+    if config.selected_target_name and "target_name" in out.columns:
+        out = out[out["target_name"].astype(str).eq(config.selected_target_name)]
+    return out
+
+
+def _target_from_row(config: TradingConfig, row: pd.Series) -> PredictionTarget | None:
+    mode = str(row["target_mode"])
+    selected_name = str(row["target_name"])
+    selected_col = str(row["target_col"])
+
+    for base in default_prediction_targets(config):
+        candidate = PredictionTarget(
+            name=selected_name,
+            symbol=base.symbol,
+            horizon_days=base.horizon_days,
+            up_threshold=base.up_threshold,
+            down_threshold=base.down_threshold,
+            mode=mode,
+        )
+        if selected_col == target_column(candidate) or selected_name.startswith(base.name):
+            return candidate
+    return None
+
+
+def _default_selection(target: PredictionTarget, reason: str) -> SelectedTarget:
+    return SelectedTarget(
+        target=target,
+        target_name=target.name,
+        target_mode=target.mode,
+        target_col=target_column(target),
+        model=None,
+        mean_roc_auc=None,
+        mean_profit_factor=None,
+        worst_fold_drawdown=None,
+        score=None,
+        source="default_config",
+        fallback_reason=reason,
+    )
+
+
+def _optional_float(row: pd.Series, column: str) -> float | None:
+    if column not in row or pd.isna(row[column]):
+        return None
+    return float(row[column])
+
+
+def format_selected_target(selection: SelectedTarget) -> str:
+    lines = [
+        "== Selected model target ==",
+        f"target_name: {selection.target_name}",
+        f"target_mode: {selection.target_mode}",
+        f"target_col: {selection.target_col}",
+        f"model: {selection.model or 'n/a'}",
+        f"mean_roc_auc: {_fmt(selection.mean_roc_auc)}",
+        f"mean_profit_factor: {_fmt(selection.mean_profit_factor)}",
+        f"worst_fold_drawdown: {_fmt(selection.worst_fold_drawdown)}",
+        f"score: {_fmt(selection.score)}",
+        f"source: {selection.source}",
+    ]
+    if selection.fallback_reason:
+        lines.append(f"fallback_reason: {selection.fallback_reason}")
+    return "\n".join(lines) + "\n"
+
+
+def _fmt(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.6g}"
+
+
+def main() -> None:
+    print(format_selected_target(selected_prediction_target()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trading_lab/models/zoo.py
+++ b/src/trading_lab/models/zoo.py
@@ -16,12 +16,13 @@ from trading_lab.backtests.walk_forward import _event_returns, _summarize
 from trading_lab.config import TradingColumns, TradingConfig, load_trading_config
 from trading_lab.config.targets import PredictionTarget
 from trading_lab.models.dataset import (
+    ensure_target_column,
     feature_columns,
     load_market_features,
-    primary_prediction_target,
     supervised_frame,
     target_column,
 )
+from trading_lab.models.target_selection import selected_prediction_target
 
 
 FEATURE_PATH = Path("data/processed/market/market_features.csv")
@@ -118,11 +119,12 @@ class MarketDataset:
     ) -> None:
         self.feature_path = feature_path
         self.config = config or load_trading_config()
-        self.target = target or primary_prediction_target(self.config)
+        self.target = target or selected_prediction_target(self.config).target
         self.target_col = target_col or target_column(self.target)
 
     def load(self) -> tuple[pd.DataFrame, list[str]]:
         df = load_market_features(self.feature_path)
+        df = ensure_target_column(df, self.target)
         if self.target_col != target_column(self.target):
             target_col = self.target_col
             _, feature_cols, _ = self._supervised_by_column(df, target_col)
@@ -321,8 +323,9 @@ def default_configs() -> list[ModelConfig]:
 
 
 def run_model_zoo() -> pd.DataFrame:
+    config = load_trading_config()
     zoo = WalkForwardModelZoo(
-        dataset=MarketDataset(),
+        dataset=MarketDataset(config=config),
         configs=default_configs(),
     )
     _, _, ranking = zoo.write_reports()

--- a/src/trading_lab/signals/latest_regime.py
+++ b/src/trading_lab/signals/latest_regime.py
@@ -5,12 +5,15 @@ from pathlib import Path
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 
+from trading_lab.config import TradingConfig, load_trading_config
 from trading_lab.models.dataset import (
     feature_columns,
     latest_feature_row,
     load_market_features,
+    primary_prediction_target,
     supervised_frame,
 )
+from trading_lab.models.target_selection import SelectedTarget, selected_prediction_target
 
 
 FEATURE_PATH = Path("data/processed/market/market_features.csv")
@@ -24,10 +27,14 @@ def regime_feature_columns(df: pd.DataFrame) -> list[str]:
 def score_latest_regime(
     feature_path: Path = FEATURE_PATH,
     out_path: Path = OUT_PATH,
+    config: TradingConfig | None = None,
+    selected_target: SelectedTarget | None = None,
 ) -> pd.DataFrame:
+    cfg = config or load_trading_config()
     df = load_market_features(feature_path)
-    train, feature_cols, _ = supervised_frame(df)
-    latest, _ = latest_feature_row(df)
+    target_selection = selected_target or selected_prediction_target(cfg)
+    train, feature_cols, target_col = supervised_frame(df, target=target_selection.target, config=cfg)
+    latest, _ = latest_feature_row(df, cfg)
 
     model = RandomForestClassifier(
         n_estimators=300,
@@ -47,6 +54,10 @@ def score_latest_regime(
                 "random_forest_proba": proba,
                 "train_rows": len(train),
                 "target_positive_rate": float(train["target"].mean()),
+                "configured_target_mode": primary_prediction_target(cfg).mode,
+                "active_target_mode": target_selection.target_mode,
+                "active_target_col": target_col,
+                "target_source": target_selection.source,
             }
         ]
     )

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -10,6 +10,9 @@ def test_default_trading_config_is_current_tqqq_setup():
     assert cfg.benchmark_symbol == "QQQ"
     assert cfg.core_symbol == "SPY"
     assert cfg.inverse_symbol == "SQQQ"
+    assert cfg.use_experiment_selected_target is False
+    assert cfg.selected_target_mode is None
+    assert cfg.selected_target_name is None
 
 
 def test_load_trading_config_from_yaml(tmp_path: Path):
@@ -26,6 +29,10 @@ account:
 allocation:
   max_traded_allocation_wait: 0.07
   max_core_allocation_wait: 0.44
+modeling:
+  use_experiment_selected_target: true
+  selected_target_mode: threshold_horizon_return
+  selected_target_name: soxl_5d_up5_before_down5_threshold_horizon_return
 """,
         encoding="utf-8",
     )
@@ -38,3 +45,6 @@ allocation:
     assert cfg.account_value == 1234
     assert cfg.max_traded_allocation_wait == 0.07
     assert cfg.max_core_allocation_wait == 0.44
+    assert cfg.use_experiment_selected_target is True
+    assert cfg.selected_target_mode == "threshold_horizon_return"
+    assert cfg.selected_target_name == "soxl_5d_up5_before_down5_threshold_horizon_return"

--- a/tests/test_model_dataset.py
+++ b/tests/test_model_dataset.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from trading_lab.config import TradingConfig
+from trading_lab.config.targets import PredictionTarget
 from trading_lab.models.dataset import (
     feature_columns,
     latest_feature_row,
@@ -62,3 +63,21 @@ def test_latest_feature_row_and_time_splits_are_chronological():
     assert latest.iloc[0]["date"] == pd.Timestamp("2024-01-06")
     assert train["date"].max() < test["date"].min()
     assert len(folds) == 2
+
+
+def test_supervised_frame_generates_missing_selected_target_column():
+    config = TradingConfig(traded_symbol="SOXL", benchmark_symbol="XLK")
+    target = PredictionTarget(
+        name="soxl_5d_threshold",
+        symbol="SOXL",
+        horizon_days=2,
+        up_threshold=0.10,
+        down_threshold=-0.05,
+        mode="threshold_horizon_return",
+    )
+
+    work, _, target_col = supervised_frame(_frame(), target=target, config=config)
+
+    assert target_col == "SOXL_threshold_horizon_return_up10pct_2d"
+    assert target_col in work.columns
+    assert set(work["target"].unique()).issubset({0, 1})

--- a/tests/test_model_live.py
+++ b/tests/test_model_live.py
@@ -1,6 +1,10 @@
 import pandas as pd
 
+from trading_lab.config import TradingConfig
+from trading_lab.config.targets import PredictionTarget
 from trading_lab.models.live import OUT_PATH
+from trading_lab.models.live import score_selected_model_latest
+from trading_lab.models.target_selection import SelectedTarget
 
 
 def test_selected_model_signal_output_path_name():
@@ -18,6 +22,10 @@ def test_selected_model_signal_schema_example():
                 "target_positive_rate": 0.36,
                 "selected_model_profit_factor": 2.5,
                 "selected_model_worst_drawdown": -0.34,
+                "configured_target_mode": "barrier_first_hit",
+                "active_target_mode": "threshold_horizon_return",
+                "active_target_col": "TQQQ_threshold_horizon_return_up5pct_5d",
+                "target_source": "experiment_report",
             }
         ]
     )
@@ -30,4 +38,68 @@ def test_selected_model_signal_schema_example():
         "target_positive_rate",
         "selected_model_profit_factor",
         "selected_model_worst_drawdown",
+        "configured_target_mode",
+        "active_target_mode",
+        "active_target_col",
+        "target_source",
     }
+
+
+def test_selected_model_latest_accepts_selected_target_without_tqqq_assumptions(tmp_path, monkeypatch):
+    feature_path = tmp_path / "features.csv"
+    out_path = tmp_path / "signal.csv"
+    prices = [100, 106, 98, 109, 101, 112, 103, 115, 104, 118, 106, 121]
+    pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=len(prices)),
+            "SOXL": prices,
+            "SOXL_ret_1d": pd.Series(prices).pct_change().fillna(0.0),
+            "SOXL_dist_ma_20": [0.01] * len(prices),
+            "SOXL_vol_5d": [0.2] * len(prices),
+            "XLK_ret_1d": [0.01, -0.01] * 6,
+            "XLK_uptrend_20_50": [True] * len(prices),
+            "SPY_ret_1d": [0.005, -0.005] * 6,
+        }
+    ).to_csv(feature_path, index=False)
+
+    class Winner:
+        model = "logistic_regression"
+        mean_profit_factor = 1.2
+        worst_fold_drawdown = -0.2
+
+    monkeypatch.setattr("trading_lab.models.live.select_model_zoo_winner", lambda: Winner())
+    target = PredictionTarget(
+        name="soxl_threshold",
+        symbol="SOXL",
+        horizon_days=1,
+        up_threshold=0.05,
+        down_threshold=-0.05,
+        mode="threshold_horizon_return",
+    )
+    selected = SelectedTarget(
+        target=target,
+        target_name=target.name,
+        target_mode=target.mode,
+        target_col="SOXL_threshold_horizon_return_up5pct_1d",
+        model="logistic_regression",
+        mean_roc_auc=0.7,
+        mean_profit_factor=1.5,
+        worst_fold_drawdown=-0.1,
+        score=0.4,
+        source="experiment_report",
+    )
+
+    out = score_selected_model_latest(
+        feature_path=feature_path,
+        out_path=out_path,
+        config=TradingConfig(
+            traded_symbol="SOXL",
+            benchmark_symbol="XLK",
+            use_experiment_selected_target=True,
+        ),
+        selected_target=selected,
+    )
+
+    assert out.loc[0, "active_target_mode"] == "threshold_horizon_return"
+    assert out.loc[0, "active_target_col"] == "SOXL_threshold_horizon_return_up5pct_1d"
+    assert out_path.exists()

--- a/tests/test_target_selection.py
+++ b/tests/test_target_selection.py
@@ -1,0 +1,87 @@
+import pandas as pd
+
+from trading_lab.config import TradingConfig
+from trading_lab.models.target_selection import select_best_target, selected_prediction_target
+
+
+def _report():
+    return pd.DataFrame(
+        [
+            {
+                "target_name": "soxl_5d_up5_before_down5_barrier_first_hit",
+                "target_mode": "barrier_first_hit",
+                "target_col": "SOXL_hit_up_before_down_5d",
+                "model": "random_forest",
+                "mean_roc_auc": 0.60,
+                "mean_profit_factor": float("inf"),
+                "worst_fold_drawdown": -0.01,
+                "score": 0.9,
+            },
+            {
+                "target_name": "soxl_5d_up5_before_down5_threshold_horizon_return",
+                "target_mode": "threshold_horizon_return",
+                "target_col": "SOXL_threshold_horizon_return_up5pct_5d",
+                "model": "logistic_regression",
+                "mean_roc_auc": 0.70,
+                "mean_profit_factor": 1.5,
+                "worst_fold_drawdown": -0.10,
+                "score": 0.5,
+            },
+            {
+                "target_name": "soxl_5d_up5_before_down5_horizon_return",
+                "target_mode": "horizon_return",
+                "target_col": "SOXL_horizon_return_5d",
+                "model": "random_forest_deeper",
+                "mean_roc_auc": 0.65,
+                "mean_profit_factor": 2.0,
+                "worst_fold_drawdown": -0.05,
+                "score": 0.8,
+            },
+        ]
+    )
+
+
+def test_default_config_keeps_primary_target():
+    selection = selected_prediction_target(
+        TradingConfig(traded_symbol="SOXL", benchmark_symbol="XLK"),
+        report_df=_report(),
+    )
+
+    assert selection.source == "default_config"
+    assert selection.target_mode == "barrier_first_hit"
+    assert selection.target_col == "SOXL_hit_up_before_down_5d"
+
+
+def test_experiment_selected_config_picks_best_finite_candidate():
+    config = TradingConfig(
+        traded_symbol="SOXL",
+        benchmark_symbol="XLK",
+        use_experiment_selected_target=True,
+    )
+
+    selection = selected_prediction_target(config, report_df=_report())
+
+    assert selection.source == "experiment_report"
+    assert selection.target_mode == "threshold_horizon_return"
+    assert selection.target_col == "SOXL_threshold_horizon_return_up5pct_5d"
+    assert selection.model == "logistic_regression"
+
+
+def test_missing_report_falls_back_cleanly():
+    config = TradingConfig(
+        traded_symbol="SOXL",
+        benchmark_symbol="XLK",
+        use_experiment_selected_target=True,
+    )
+
+    selection = selected_prediction_target(config, report_df=pd.DataFrame())
+
+    assert selection.source == "default_config"
+    assert selection.fallback_reason == "experiment report missing or empty"
+
+
+def test_select_best_target_prefers_finite_profit_factor_before_inf():
+    row = select_best_target(_report())
+
+    assert row is not None
+    assert row["model"] == "logistic_regression"


### PR DESCRIPTION
Adds an opt-in path to select the best target mode from the model experiment report for live/model scoring while preserving the default target behavior. Advances issues #2 and #4.