### PR TITLE
Add research profile for experiment-selected targets

### DIFF
--- a/scripts/tl_research_daily.sh
+++ b/scripts/tl_research_daily.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TRADING_LAB_PROFILE=research python -m trading_lab.workflows.full_daily

--- a/scripts/tl_research_status.sh
+++ b/scripts/tl_research_status.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TRADING_LAB_PROFILE=research python -m trading_lab.cli.status "$@"

--- a/src/trading_lab/config/profiles.py
+++ b/src/trading_lab/config/profiles.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+
+
+PROFILE_ENV = "TRADING_LAB_PROFILE"
+TARGET_OVERRIDE_ENV = "TRADING_LAB_USE_EXPERIMENT_SELECTED_TARGET"
+DEFAULT_PROFILE = "default"
+RESEARCH_PROFILE = "research"
+
+
+def active_profile(environ: dict[str, str] | None = None) -> str:
+    return profile_from_env(environ) or DEFAULT_PROFILE
+
+
+def profile_from_env(environ: dict[str, str] | None = None) -> str | None:
+    env = environ if environ is not None else os.environ
+    raw = env.get(PROFILE_ENV)
+    if raw is None:
+        return None
+    profile = raw.strip().lower()
+    if profile not in {DEFAULT_PROFILE, RESEARCH_PROFILE}:
+        return None
+    return profile
+
+
+def profile_uses_experiment_target(profile: str) -> bool:
+    return profile == RESEARCH_PROFILE
+
+
+def bool_env_override(environ: dict[str, str] | None = None) -> bool | None:
+    env = environ if environ is not None else os.environ
+    raw = env.get(TARGET_OVERRIDE_ENV)
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return None

--- a/src/trading_lab/config/settings.py
+++ b/src/trading_lab/config/settings.py
@@ -5,6 +5,14 @@ from pathlib import Path
 
 import yaml
 
+from trading_lab.config.profiles import (
+    DEFAULT_PROFILE,
+    active_profile,
+    bool_env_override,
+    profile_from_env,
+    profile_uses_experiment_target,
+)
+
 
 DEFAULT_CONFIG_PATH = Path("config/trading.yaml")
 
@@ -21,6 +29,7 @@ class TradingConfig:
     use_experiment_selected_target: bool = False
     selected_target_mode: str | None = None
     selected_target_name: str | None = None
+    active_profile: str = "default"
 
     @property
     def traded_upper(self) -> str:
@@ -32,14 +41,37 @@ class TradingConfig:
 
 
 def load_trading_config(path: Path = DEFAULT_CONFIG_PATH) -> TradingConfig:
+    profile = active_profile()
+    selected_profile = profile_from_env()
+    override = bool_env_override()
     if not path.exists():
-        return TradingConfig()
+        return TradingConfig(
+            use_experiment_selected_target=(
+                override
+                if override is not None
+                else profile_uses_experiment_target(selected_profile or DEFAULT_PROFILE)
+            ),
+            active_profile=profile,
+        )
 
     data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     symbols = data.get("symbols", {})
     account = data.get("account", {})
     allocation = data.get("allocation", {})
     modeling = data.get("modeling", {})
+    file_use_experiment = bool(
+        modeling.get(
+            "use_experiment_selected_target",
+            TradingConfig.use_experiment_selected_target,
+        )
+    )
+    use_experiment = (
+        override
+        if override is not None
+        else profile_uses_experiment_target(selected_profile)
+        if selected_profile is not None
+        else file_use_experiment
+    )
 
     return TradingConfig(
         traded_symbol=str(symbols.get("traded", TradingConfig.traded_symbol)),
@@ -53,12 +85,8 @@ def load_trading_config(path: Path = DEFAULT_CONFIG_PATH) -> TradingConfig:
         max_core_allocation_wait=float(
             allocation.get("max_core_allocation_wait", TradingConfig.max_core_allocation_wait)
         ),
-        use_experiment_selected_target=bool(
-            modeling.get(
-                "use_experiment_selected_target",
-                TradingConfig.use_experiment_selected_target,
-            )
-        ),
+        use_experiment_selected_target=use_experiment,
         selected_target_mode=modeling.get("selected_target_mode"),
         selected_target_name=modeling.get("selected_target_name"),
+        active_profile=profile,
     )

--- a/src/trading_lab/dashboard/daily.py
+++ b/src/trading_lab/dashboard/daily.py
@@ -95,6 +95,7 @@ def build_daily_decision_summary() -> str:
         f"{cfg.traded_symbol}: {traded_price:.2f}",
         f"RF probability: {baseline_prob:.3f}",
         f"Selected model probability ({selected_model_name}): {selected_model_prob:.3f}",
+        f"Profile: {cfg.active_profile}",
         f"Configured target mode: {configured_target_mode}",
         f"Active target mode: {active_target_mode}",
         f"Active target column: {active_target_col}",

--- a/src/trading_lab/models/target_selection.py
+++ b/src/trading_lab/models/target_selection.py
@@ -147,9 +147,12 @@ def _optional_float(row: pd.Series, column: str) -> float | None:
     return float(row[column])
 
 
-def format_selected_target(selection: SelectedTarget) -> str:
+def format_selected_target(selection: SelectedTarget, config: TradingConfig | None = None) -> str:
+    cfg = config or load_trading_config()
     lines = [
         "== Selected model target ==",
+        f"active_profile: {cfg.active_profile}",
+        f"experiment_selected_target_enabled: {cfg.use_experiment_selected_target}",
         f"target_name: {selection.target_name}",
         f"target_mode: {selection.target_mode}",
         f"target_col: {selection.target_col}",
@@ -170,7 +173,8 @@ def _fmt(value: float | None) -> str:
 
 
 def main() -> None:
-    print(format_selected_target(selected_prediction_target()))
+    cfg = load_trading_config()
+    print(format_selected_target(selected_prediction_target(cfg), cfg))
 
 
 if __name__ == "__main__":

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from trading_lab.config import TradingConfig, load_trading_config
 
 
-def test_default_trading_config_is_current_tqqq_setup():
+def test_default_trading_config_is_current_tqqq_setup(monkeypatch):
+    monkeypatch.delenv("TRADING_LAB_PROFILE", raising=False)
+    monkeypatch.delenv("TRADING_LAB_USE_EXPERIMENT_SELECTED_TARGET", raising=False)
     cfg = TradingConfig()
 
     assert cfg.traded_symbol == "TQQQ"
@@ -13,9 +15,12 @@ def test_default_trading_config_is_current_tqqq_setup():
     assert cfg.use_experiment_selected_target is False
     assert cfg.selected_target_mode is None
     assert cfg.selected_target_name is None
+    assert cfg.active_profile == "default"
 
 
-def test_load_trading_config_from_yaml(tmp_path: Path):
+def test_load_trading_config_from_yaml(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("TRADING_LAB_PROFILE", raising=False)
+    monkeypatch.delenv("TRADING_LAB_USE_EXPERIMENT_SELECTED_TARGET", raising=False)
     path = tmp_path / "trading.yaml"
     path.write_text(
         """
@@ -48,3 +53,61 @@ modeling:
     assert cfg.use_experiment_selected_target is True
     assert cfg.selected_target_mode == "threshold_horizon_return"
     assert cfg.selected_target_name == "soxl_5d_up5_before_down5_threshold_horizon_return"
+
+
+def test_explicit_default_profile_overrides_config_to_conservative(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TRADING_LAB_PROFILE", "default")
+    monkeypatch.delenv("TRADING_LAB_USE_EXPERIMENT_SELECTED_TARGET", raising=False)
+    path = tmp_path / "trading.yaml"
+    path.write_text(
+        """
+modeling:
+  use_experiment_selected_target: true
+""",
+        encoding="utf-8",
+    )
+
+    cfg = load_trading_config(path)
+
+    assert cfg.active_profile == "default"
+    assert cfg.use_experiment_selected_target is False
+
+
+def test_default_profile_keeps_experiment_selected_false(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("TRADING_LAB_PROFILE", raising=False)
+    monkeypatch.delenv("TRADING_LAB_USE_EXPERIMENT_SELECTED_TARGET", raising=False)
+
+    cfg = load_trading_config(tmp_path / "missing.yaml")
+
+    assert cfg.active_profile == "default"
+    assert cfg.use_experiment_selected_target is False
+
+
+def test_research_profile_enables_experiment_selected(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TRADING_LAB_PROFILE", "research")
+    monkeypatch.delenv("TRADING_LAB_USE_EXPERIMENT_SELECTED_TARGET", raising=False)
+
+    cfg = load_trading_config(tmp_path / "missing.yaml")
+
+    assert cfg.active_profile == "research"
+    assert cfg.use_experiment_selected_target is True
+
+
+def test_env_override_can_disable_research_profile(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TRADING_LAB_PROFILE", "research")
+    monkeypatch.setenv("TRADING_LAB_USE_EXPERIMENT_SELECTED_TARGET", "0")
+
+    cfg = load_trading_config(tmp_path / "missing.yaml")
+
+    assert cfg.active_profile == "research"
+    assert cfg.use_experiment_selected_target is False
+
+
+def test_env_override_can_enable_default_profile(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("TRADING_LAB_PROFILE", raising=False)
+    monkeypatch.setenv("TRADING_LAB_USE_EXPERIMENT_SELECTED_TARGET", "1")
+
+    cfg = load_trading_config(tmp_path / "missing.yaml")
+
+    assert cfg.active_profile == "default"
+    assert cfg.use_experiment_selected_target is True

--- a/tests/test_target_selection.py
+++ b/tests/test_target_selection.py
@@ -1,7 +1,11 @@
 import pandas as pd
 
 from trading_lab.config import TradingConfig
-from trading_lab.models.target_selection import select_best_target, selected_prediction_target
+from trading_lab.models.target_selection import (
+    format_selected_target,
+    select_best_target,
+    selected_prediction_target,
+)
 
 
 def _report():
@@ -85,3 +89,15 @@ def test_select_best_target_prefers_finite_profit_factor_before_inf():
 
     assert row is not None
     assert row["model"] == "logistic_regression"
+
+
+def test_select_target_output_reports_profile_and_source():
+    config = TradingConfig(traded_symbol="SOXL", benchmark_symbol="XLK", active_profile="research")
+    selection = selected_prediction_target(config, report_df=pd.DataFrame())
+
+    text = format_selected_target(selection, config)
+
+    assert "active_profile: research" in text
+    assert "experiment_selected_target_enabled: False" in text
+    assert "source: default_config" in text
+    assert "fallback_reason: experiment target selection disabled" in text


### PR DESCRIPTION
Adds a research profile that enables experiment-selected targets while preserving conservative default behavior. Adds thin research workflow wrappers and tests.