### PR TITLE
Add local portfolio state to daily decision workflow

### DIFF
--- a/src/trading_lab/cli/main.py
+++ b/src/trading_lab/cli/main.py
@@ -26,6 +26,24 @@ def main() -> None:
     decide.add_argument("--position", action="append", default=[])
     decide.add_argument("--cash", type=float)
 
+    portfolio = sub.add_parser("portfolio")
+    portfolio_sub = portfolio.add_subparsers(dest="portfolio_command")
+    portfolio_status = portfolio_sub.add_parser("status")
+    portfolio_status.add_argument("--account-value", type=float)
+    portfolio_status.add_argument("--cash", type=float)
+    portfolio_sub.add_parser("positions")
+    portfolio_sub.add_parser("orders")
+    portfolio_set = portfolio_sub.add_parser("set")
+    portfolio_set.add_argument("symbol")
+    portfolio_set.add_argument("quantity", type=float)
+    portfolio_order = portfolio_sub.add_parser("order")
+    portfolio_order_sub = portfolio_order.add_subparsers(dest="portfolio_order_command")
+    portfolio_order_add = portfolio_order_sub.add_parser("add")
+    portfolio_order_add.add_argument("side", choices=["buy", "sell"])
+    portfolio_order_add.add_argument("symbol")
+    portfolio_order_add.add_argument("quantity", type=float)
+    portfolio_order_add.add_argument("limit_price", type=float)
+
     args, rest = parser.parse_known_args()
     command = args.command or "status"
 
@@ -54,11 +72,21 @@ def main() -> None:
         )
         return
 
+    if command == "portfolio":
+        _portfolio_command(args)
+        return
+
     if command == "plots":
-        raise SystemExit(_run([sys.executable, "scripts/plot_dashboard.py"]) or _run([sys.executable, "-m", "trading_lab.plots.open_plots"]))
+        raise SystemExit(
+            _run([sys.executable, "scripts/plot_dashboard.py"])
+            or _run([sys.executable, "-m", "trading_lab.plots.open_plots"])
+        )
 
     if command == "orders":
-        raise SystemExit(_run([sys.executable, "scripts/parse_open_orders.py"]) or _run([sys.executable, "scripts/reconcile_orders.py"]))
+        raise SystemExit(
+            _run([sys.executable, "scripts/parse_open_orders.py"])
+            or _run([sys.executable, "scripts/reconcile_orders.py"])
+        )
 
     if command == "demo":
         from trading_lab.workflows.demo import run_demo
@@ -73,6 +101,72 @@ def main() -> None:
         raise SystemExit(_run([sys.executable, "-m", "trading_lab.devtools.audit"]))
 
     raise SystemExit(f"Unknown command: {command}")
+
+
+def _portfolio_command(args: argparse.Namespace) -> None:
+    from trading_lab.portfolio.state import (
+        OPEN_ORDERS_PATH,
+        POSITIONS_PATH,
+        append_open_order,
+        build_portfolio_state,
+        read_open_orders,
+        read_positions,
+        summarize_portfolio_state,
+        write_position,
+    )
+
+    command = args.portfolio_command or "status"
+    if command == "status":
+        print(
+            summarize_portfolio_state(
+                build_portfolio_state(account_value=args.account_value, cash=args.cash)
+            )
+        )
+        return
+    if command == "positions":
+        positions = read_positions()
+        if not positions:
+            print(f"No local positions found at {POSITIONS_PATH}.")
+            return
+        for position in positions:
+            print(
+                f"{position.symbol},{position.quantity:g},{position.notes},{position.updated_at}"
+            )
+        return
+    if command == "orders":
+        orders = read_open_orders()
+        if not orders:
+            print(f"No local open orders found at {OPEN_ORDERS_PATH}.")
+            return
+        for order in orders:
+            print(
+                f"{order.symbol},{order.side},{order.type},{order.quantity:g},"
+                f"{order.limit_price:.2f},{order.time_in_force},{order.status},"
+                f"{order.submitted_at},{order.notes}"
+            )
+        return
+    if command == "set":
+        write_position(POSITIONS_PATH, args.symbol, args.quantity)
+        print(f"Updated local position for {args.symbol.upper()} in {POSITIONS_PATH}.")
+        return
+    if command == "order":
+        if args.portfolio_order_command != "add":
+            raise SystemExit(
+                "Usage: tl portfolio order add {buy,sell} SYMBOL QUANTITY LIMIT_PRICE"
+            )
+        append_open_order(
+            OPEN_ORDERS_PATH,
+            side=args.side,
+            symbol=args.symbol,
+            quantity=args.quantity,
+            limit_price=args.limit_price,
+        )
+        print(
+            f"Added local {args.side} limit order for "
+            f"{args.symbol.upper()} in {OPEN_ORDERS_PATH}."
+        )
+        return
+    raise SystemExit(f"Unknown portfolio command: {command}")
 
 
 if __name__ == "__main__":

--- a/src/trading_lab/cli/main.py
+++ b/src/trading_lab/cli/main.py
@@ -25,6 +25,11 @@ def main() -> None:
     decide.add_argument("--account-value", type=float)
     decide.add_argument("--position", action="append", default=[])
     decide.add_argument("--cash", type=float)
+    decide.add_argument(
+        "--risk-mode",
+        choices=["conservative", "balanced", "aggressive"],
+        default="conservative",
+    )
 
     portfolio = sub.add_parser("portfolio")
     portfolio_sub = portfolio.add_subparsers(dest="portfolio_command")
@@ -92,6 +97,7 @@ def main() -> None:
                 account_value=args.account_value,
                 positions=args.position,
                 cash=args.cash,
+                risk_mode=args.risk_mode,
             )
         )
         return

--- a/src/trading_lab/cli/main.py
+++ b/src/trading_lab/cli/main.py
@@ -33,6 +33,7 @@ def main() -> None:
     portfolio_status.add_argument("--cash", type=float)
     portfolio_sub.add_parser("positions")
     portfolio_sub.add_parser("orders")
+    portfolio_sub.add_parser("gui")
     portfolio_set = portfolio_sub.add_parser("set")
     portfolio_set.add_argument("symbol")
     portfolio_set.add_argument("quantity", type=float)
@@ -43,6 +44,29 @@ def main() -> None:
     portfolio_order_add.add_argument("symbol")
     portfolio_order_add.add_argument("quantity", type=float)
     portfolio_order_add.add_argument("limit_price", type=float)
+
+    update = sub.add_parser("update")
+    update_sub = update.add_subparsers(dest="update_command")
+    for name in ("buy", "sell", "set"):
+        update_position = update_sub.add_parser(name)
+        update_position.add_argument("symbol")
+        update_position.add_argument("quantity", type=float)
+        if name == "sell":
+            update_position.add_argument("--allow-negative", action="store_true")
+    update_cash = update_sub.add_parser("cash")
+    update_cash.add_argument("amount", type=float)
+    update_account = update_sub.add_parser("account-value")
+    update_account.add_argument("amount", type=float)
+    update_order = update_sub.add_parser("order")
+    update_order_sub = update_order.add_subparsers(dest="update_order_command")
+    for side in ("buy", "sell"):
+        update_order_add = update_order_sub.add_parser(side)
+        update_order_add.add_argument("symbol")
+        update_order_add.add_argument("quantity", type=float)
+        update_order_add.add_argument("limit_price", type=float)
+    update_order_clear = update_order_sub.add_parser("clear")
+    update_order_clear.add_argument("symbol")
+    update_order_sub.add_parser("clear-all")
 
     args, rest = parser.parse_known_args()
     command = args.command or "status"
@@ -74,6 +98,10 @@ def main() -> None:
 
     if command == "portfolio":
         _portfolio_command(args)
+        return
+
+    if command == "update":
+        _update_command(args)
         return
 
     if command == "plots":
@@ -145,6 +173,11 @@ def _portfolio_command(args: argparse.Namespace) -> None:
                 f"{order.submitted_at},{order.notes}"
             )
         return
+    if command == "gui":
+        from trading_lab.portfolio.gui import run_gui
+
+        run_gui()
+        return
     if command == "set":
         write_position(POSITIONS_PATH, args.symbol, args.quantity)
         print(f"Updated local position for {args.symbol.upper()} in {POSITIONS_PATH}.")
@@ -167,6 +200,100 @@ def _portfolio_command(args: argparse.Namespace) -> None:
         )
         return
     raise SystemExit(f"Unknown portfolio command: {command}")
+
+
+def _update_command(args: argparse.Namespace) -> None:
+    from trading_lab.portfolio.state import (
+        ACCOUNT_PATH,
+        OPEN_ORDERS_PATH,
+        POSITIONS_PATH,
+        append_open_order,
+        clear_open_orders,
+        update_position_quantity,
+        write_account_value,
+        write_position,
+    )
+
+    command = args.update_command
+    if command == "buy":
+        before, after = update_position_quantity(POSITIONS_PATH, args.symbol, args.quantity)
+        print(
+            f"Local-only update: {args.symbol.upper()} position {before:g} -> {after:g} "
+            f"in {POSITIONS_PATH}."
+        )
+        return
+    if command == "sell":
+        before, after = update_position_quantity(
+            POSITIONS_PATH,
+            args.symbol,
+            -args.quantity,
+            allow_negative=args.allow_negative,
+        )
+        print(
+            f"Local-only update: {args.symbol.upper()} position {before:g} -> {after:g} "
+            f"in {POSITIONS_PATH}."
+        )
+        return
+    if command == "set":
+        write_position(POSITIONS_PATH, args.symbol, args.quantity)
+        print(
+            f"Local-only update: set {args.symbol.upper()} position to {args.quantity:g} "
+            f"in {POSITIONS_PATH}."
+        )
+        return
+    if command == "cash":
+        write_account_value(ACCOUNT_PATH, "cash", args.amount)
+        print(f"Local-only update: set cash to ${args.amount:,.2f} in {ACCOUNT_PATH}.")
+        return
+    if command == "account-value":
+        write_account_value(ACCOUNT_PATH, "account_value", args.amount)
+        print(
+            f"Local-only update: set account value to ${args.amount:,.2f} "
+            f"in {ACCOUNT_PATH}."
+        )
+        return
+    if command == "order":
+        _update_order_command(args, OPEN_ORDERS_PATH, append_open_order, clear_open_orders)
+        return
+    raise SystemExit("Usage: tl update {buy,sell,set,cash,account-value,order} ...")
+
+
+def _update_order_command(
+    args: argparse.Namespace,
+    open_orders_path,
+    append_open_order,
+    clear_open_orders,
+) -> None:
+    command = args.update_order_command
+    if command in {"buy", "sell"}:
+        append_open_order(
+            open_orders_path,
+            side=command,
+            symbol=args.symbol,
+            quantity=args.quantity,
+            limit_price=args.limit_price,
+        )
+        print(
+            f"Local-only update: added placed {command} limit order for "
+            f"{args.quantity:g} {args.symbol.upper()} at ${args.limit_price:,.2f} "
+            f"in {open_orders_path}."
+        )
+        return
+    if command == "clear":
+        cleared = clear_open_orders(open_orders_path, args.symbol)
+        print(
+            f"Local-only update: marked {cleared} open order(s) for "
+            f"{args.symbol.upper()} canceled in {open_orders_path}."
+        )
+        return
+    if command == "clear-all":
+        cleared = clear_open_orders(open_orders_path)
+        print(
+            f"Local-only update: marked {cleared} open order(s) canceled "
+            f"in {open_orders_path}."
+        )
+        return
+    raise SystemExit("Usage: tl update order {buy,sell,clear,clear-all} ...")
 
 
 if __name__ == "__main__":

--- a/src/trading_lab/data/market.py
+++ b/src/trading_lab/data/market.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pandas as pd
 import yfinance as yf
 
+from trading_lab.portfolio.state import collect_portfolio_symbols
+
 
 DEFAULT_SYMBOLS_PATH = Path("config/market_symbols.txt")
 DEFAULT_OUT_DIR = Path("data/raw/market")
@@ -43,6 +45,17 @@ def load_market_symbols(path: Path = DEFAULT_SYMBOLS_PATH) -> list[str]:
         symbols.append(symbol)
 
     return symbols
+
+
+def market_symbol_universe(config_symbols: list[str] | None = None) -> list[str]:
+    """Return configured market symbols plus symbols found in local portfolio CSVs."""
+    symbols = load_market_symbols() if config_symbols is None else config_symbols
+    combined: dict[str, None] = {}
+    for symbol in [*symbols, *collect_portfolio_symbols()]:
+        clean = symbol.strip().upper()
+        if clean:
+            combined[clean] = None
+    return list(combined)
 
 
 def csv_has_today_data(path: Path, today: date | None = None) -> bool:
@@ -115,7 +128,7 @@ def update_market_data(
     start: str = DEFAULT_START,
     force: bool = False,
 ) -> dict[str, int]:
-    symbols = symbols or load_market_symbols()
+    symbols = symbols or market_symbol_universe()
     out_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"Updating {len(symbols)} market CSVs under {out_dir}")

--- a/src/trading_lab/decision.py
+++ b/src/trading_lab/decision.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from trading_lab.config.profiles import PROFILE_ENV
 from trading_lab.portfolio.state import (
+    ACCOUNT_PATH,
     OPEN_ORDERS_PATH,
     POSITIONS_PATH,
     PortfolioState,
@@ -62,7 +63,7 @@ def render_daily_decision(
     positions: list[str] | tuple[str, ...] | None = None,
     positions_path: Path = POSITIONS_PATH,
     open_orders_path: Path = OPEN_ORDERS_PATH,
-    account_path: Path | None = None,
+    account_path: Path = ACCOUNT_PATH,
     market_dir: Path = DEFAULT_MARKET_DIR,
 ) -> str:
     """Render a fast read-only daily decision from existing report files."""
@@ -94,7 +95,7 @@ def load_decision_inputs(
     positions: list[str] | tuple[str, ...] | None = None,
     positions_path: Path = POSITIONS_PATH,
     open_orders_path: Path = OPEN_ORDERS_PATH,
-    account_path: Path | None = None,
+    account_path: Path = ACCOUNT_PATH,
     market_dir: Path = DEFAULT_MARKET_DIR,
 ) -> DecisionInputs | None:
     _ = manual_dir
@@ -102,12 +103,14 @@ def load_decision_inputs(
     if not summary_path.exists():
         return None
 
-    positions_path, open_orders_path, market_dir = _resolve_local_state_paths(
+    positions_path, open_orders_path, account_path, market_dir = _resolve_local_state_paths(
         reports_dir=reports_dir,
         positions_path=positions_path,
         open_orders_path=open_orders_path,
+        account_path=account_path,
         market_dir=market_dir,
     )
+    parsed_cli_positions = tuple(parse_position(value) for value in positions or ())
 
     summary_text = summary_path.read_text(encoding="utf-8")
     summary, reasons, blockers, ladder = _parse_summary(summary_text)
@@ -123,32 +126,37 @@ def load_decision_inputs(
         summary["max_traded_allocation"] = traded_allocation
 
     resolved_account_value = float(account_value if account_value is not None else 5000.0)
+    resolved_cash = cash
     local_portfolio = None
-    if portfolio_files_exist(positions_path, open_orders_path):
+    if portfolio_files_exist(positions_path, open_orders_path, account_path):
         local_portfolio = build_portfolio_state(
             positions_path=positions_path,
             open_orders_path=open_orders_path,
-            **({"account_path": account_path} if account_path is not None else {}),
+            account_path=account_path,
             market_dir=market_dir,
             account_value=account_value,
             cash=cash,
         )
         if local_portfolio.account_value is not None:
             resolved_account_value = float(local_portfolio.account_value)
+        if local_portfolio.cash is not None:
+            resolved_cash = local_portfolio.cash
 
-    if local_portfolio is not None:
+    if parsed_cli_positions:
+        parsed_positions = parsed_cli_positions
+    elif local_portfolio is not None:
         parsed_positions = tuple(
             Position(symbol=position.symbol, quantity=position.quantity)
             for position in local_portfolio.positions
         )
     else:
-        parsed_positions = tuple(parse_position(value) for value in positions or ())
+        parsed_positions = ()
 
     return DecisionInputs(
         profile=active_profile,
         traded_symbol=traded,
         account_value=resolved_account_value,
-        cash=cash,
+        cash=resolved_cash,
         positions=parsed_positions,
         summary=summary,
         reasons=tuple(reasons),
@@ -164,10 +172,11 @@ def _resolve_local_state_paths(
     reports_dir: Path,
     positions_path: Path,
     open_orders_path: Path,
+    account_path: Path,
     market_dir: Path,
-) -> tuple[Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path]:
     if reports_dir == DEFAULT_REPORTS_DIR:
-        return positions_path, open_orders_path, market_dir
+        return positions_path, open_orders_path, account_path, market_dir
 
     data_dir = reports_dir.parent
     resolved_positions = (
@@ -180,10 +189,15 @@ def _resolve_local_state_paths(
         if open_orders_path == OPEN_ORDERS_PATH
         else open_orders_path
     )
+    resolved_account = (
+        data_dir / "raw" / "portfolio" / "account.csv"
+        if account_path == ACCOUNT_PATH
+        else account_path
+    )
     resolved_market_dir = (
         data_dir / "raw" / "market" if market_dir == DEFAULT_MARKET_DIR else market_dir
     )
-    return resolved_positions, resolved_open_orders, resolved_market_dir
+    return resolved_positions, resolved_open_orders, resolved_account, resolved_market_dir
 
 
 def format_decision(inputs: DecisionInputs) -> str:
@@ -230,6 +244,9 @@ def format_decision(inputs: DecisionInputs) -> str:
         lines.append(f"Max {traded} exposure: ${max_dollars:,.2f}")
     if available_budget is not None:
         lines.append(f"Buy capacity now: ${available_budget:,.2f}")
+    lines.append(f"Account value: ${inputs.account_value:,.2f}")
+    if inputs.cash is not None:
+        lines.append(f"Cash: ${inputs.cash:,.2f}")
 
     lines.append(f"Already holding: {_holding_sentence(traded, held_qty, position_value)}")
     lines.append(f"In cash: {_cash_sentence(inputs.cash)}")

--- a/src/trading_lab/decision.py
+++ b/src/trading_lab/decision.py
@@ -22,6 +22,7 @@ from trading_lab.portfolio.review import (
     review_open_orders,
     suggested_order_ideas,
     summarize_order_reviews,
+    normalize_risk_mode,
 )
 
 
@@ -52,6 +53,7 @@ class DecisionInputs:
     ladder: tuple[str, ...]
     selected_signal: dict[str, str]
     portfolio_state: PortfolioState | None = None
+    risk_mode: str = "conservative"
 
 
 def parse_position(value: str) -> Position:
@@ -73,6 +75,7 @@ def render_daily_decision(
     open_orders_path: Path = OPEN_ORDERS_PATH,
     account_path: Path = ACCOUNT_PATH,
     market_dir: Path = DEFAULT_MARKET_DIR,
+    risk_mode: str = "conservative",
 ) -> str:
     """Render a fast read-only daily decision from existing report files."""
 
@@ -87,6 +90,7 @@ def render_daily_decision(
         open_orders_path=open_orders_path,
         account_path=account_path,
         market_dir=market_dir,
+        risk_mode=risk_mode,
     )
     if inputs is None:
         return MISSING_REPORTS_MESSAGE
@@ -105,8 +109,10 @@ def load_decision_inputs(
     open_orders_path: Path = OPEN_ORDERS_PATH,
     account_path: Path = ACCOUNT_PATH,
     market_dir: Path = DEFAULT_MARKET_DIR,
+    risk_mode: str = "conservative",
 ) -> DecisionInputs | None:
     _ = manual_dir
+    resolved_risk_mode = normalize_risk_mode(risk_mode)
     summary_path = reports_dir / SUMMARY_FILE
     if not summary_path.exists():
         return None
@@ -172,6 +178,7 @@ def load_decision_inputs(
         ladder=tuple(ladder),
         selected_signal=selected_signal,
         portfolio_state=local_portfolio,
+        risk_mode=resolved_risk_mode,
     )
 
 
@@ -236,6 +243,7 @@ def format_decision(inputs: DecisionInputs) -> str:
     lines.append(f"Now: {_now_instruction(action, traded, available_budget, holding)}")
     lines.append(f"Decision: {_decision_sentence(action, traded)}")
     lines.append(f"Profile: {inputs.profile}")
+    lines.append(f"Risk mode: {inputs.risk_mode}")
     lines.append(f"Suggested report action: {raw_action}")
     lines.append(f"Strategy eligible today: {'YES' if eligible else 'NO'}")
 
@@ -398,6 +406,7 @@ def _open_order_review_lines(
         suggested_action=inputs.summary.get("suggested_action", "NO_TRADE"),
         strategy_eligible=inputs.summary.get("strategy_eligible", "").upper() == "YES",
         ladder=inputs.ladder,
+        risk_mode=inputs.risk_mode,
     )
     summary = summarize_order_reviews(reviews)
     lines = ["Open-order review:"]
@@ -443,6 +452,7 @@ def _advice_lines(
         suggested_action=inputs.summary.get("suggested_action", "NO_TRADE"),
         strategy_eligible=inputs.summary.get("strategy_eligible", "").upper() == "YES",
         ladder=inputs.ladder,
+        risk_mode=inputs.risk_mode,
     )
     summary = summarize_order_reviews(reviews)
     context = exposure_context(state, inputs.traded_symbol, inputs.account_value, max_allocation)
@@ -453,7 +463,13 @@ def _advice_lines(
         action=action,
         max_exposure=context.max_exposure,
         order_summary=summary,
+        risk_mode=inputs.risk_mode,
     ))
+    if context.current_exposure is not None and context.max_exposure is not None:
+        lines.append(
+            f"- Exposure warning: current {inputs.traded_symbol.upper()} exposure "
+            f"{_format_money(context.current_exposure)} vs max {_format_money(context.max_exposure)}."
+        )
     lines.extend(["", "Suggested order ideas:"])
     lines.extend(f"- {line}" for line in suggested_order_ideas(
         state,
@@ -461,6 +477,7 @@ def _advice_lines(
         context=context,
         reviews=reviews,
         ladder=inputs.ladder,
+        risk_mode=inputs.risk_mode,
     ))
     return lines
 

--- a/src/trading_lab/decision.py
+++ b/src/trading_lab/decision.py
@@ -7,11 +7,19 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from trading_lab.config.profiles import PROFILE_ENV
+from trading_lab.portfolio.state import (
+    OPEN_ORDERS_PATH,
+    POSITIONS_PATH,
+    PortfolioState,
+    build_portfolio_state,
+    portfolio_files_exist,
+)
 
 
 MISSING_REPORTS_MESSAGE = "Missing reports. Run ./scripts/tl_full_daily.sh first."
 DEFAULT_REPORTS_DIR = Path("data/reports")
 DEFAULT_MANUAL_DIR = Path("data/manual")
+DEFAULT_MARKET_DIR = Path("data/raw/market")
 SUMMARY_FILE = "daily_decision_summary.txt"
 SELECTED_SIGNAL_FILE = "selected_model_latest_signal.csv"
 
@@ -34,6 +42,7 @@ class DecisionInputs:
     blockers: tuple[str, ...]
     ladder: tuple[str, ...]
     selected_signal: dict[str, str]
+    portfolio_state: PortfolioState | None = None
 
 
 def parse_position(value: str) -> Position:
@@ -51,6 +60,9 @@ def render_daily_decision(
     account_value: float | None = None,
     cash: float | None = None,
     positions: list[str] | tuple[str, ...] | None = None,
+    positions_path: Path = POSITIONS_PATH,
+    open_orders_path: Path = OPEN_ORDERS_PATH,
+    market_dir: Path = DEFAULT_MARKET_DIR,
 ) -> str:
     """Render a fast read-only daily decision from existing report files."""
 
@@ -61,6 +73,9 @@ def render_daily_decision(
         account_value=account_value,
         cash=cash,
         positions=positions,
+        positions_path=positions_path,
+        open_orders_path=open_orders_path,
+        market_dir=market_dir,
     )
     if inputs is None:
         return MISSING_REPORTS_MESSAGE
@@ -75,14 +90,23 @@ def load_decision_inputs(
     account_value: float | None = None,
     cash: float | None = None,
     positions: list[str] | tuple[str, ...] | None = None,
+    positions_path: Path = POSITIONS_PATH,
+    open_orders_path: Path = OPEN_ORDERS_PATH,
+    market_dir: Path = DEFAULT_MARKET_DIR,
 ) -> DecisionInputs | None:
     _ = manual_dir
     summary_path = reports_dir / SUMMARY_FILE
     if not summary_path.exists():
         return None
 
+    positions_path, open_orders_path, market_dir = _resolve_local_state_paths(
+        reports_dir=reports_dir,
+        positions_path=positions_path,
+        open_orders_path=open_orders_path,
+        market_dir=market_dir,
+    )
+
     summary_text = summary_path.read_text(encoding="utf-8")
-    parsed_positions = tuple(parse_position(value) for value in positions or ())
     summary, reasons, blockers, ladder = _parse_summary(summary_text)
     selected_signal = _read_latest_csv_row(reports_dir / SELECTED_SIGNAL_FILE)
     active_profile = profile or os.environ.get(PROFILE_ENV) or summary.get("profile") or "default"
@@ -95,10 +119,29 @@ def load_decision_inputs(
     if traded_allocation is not None:
         summary["max_traded_allocation"] = traded_allocation
 
+    resolved_account_value = float(account_value if account_value is not None else 5000.0)
+    local_portfolio = None
+    if portfolio_files_exist(positions_path, open_orders_path):
+        local_portfolio = build_portfolio_state(
+            positions_path=positions_path,
+            open_orders_path=open_orders_path,
+            market_dir=market_dir,
+            account_value=resolved_account_value,
+            cash=cash,
+        )
+
+    if local_portfolio is not None:
+        parsed_positions = tuple(
+            Position(symbol=position.symbol, quantity=position.quantity)
+            for position in local_portfolio.positions
+        )
+    else:
+        parsed_positions = tuple(parse_position(value) for value in positions or ())
+
     return DecisionInputs(
         profile=active_profile,
         traded_symbol=traded,
-        account_value=float(account_value if account_value is not None else 5000.0),
+        account_value=resolved_account_value,
         cash=cash,
         positions=parsed_positions,
         summary=summary,
@@ -106,7 +149,35 @@ def load_decision_inputs(
         blockers=tuple(blockers),
         ladder=tuple(ladder),
         selected_signal=selected_signal,
+        portfolio_state=local_portfolio,
     )
+
+
+def _resolve_local_state_paths(
+    *,
+    reports_dir: Path,
+    positions_path: Path,
+    open_orders_path: Path,
+    market_dir: Path,
+) -> tuple[Path, Path, Path]:
+    if reports_dir == DEFAULT_REPORTS_DIR:
+        return positions_path, open_orders_path, market_dir
+
+    data_dir = reports_dir.parent
+    resolved_positions = (
+        data_dir / "raw" / "portfolio" / "positions.csv"
+        if positions_path == POSITIONS_PATH
+        else positions_path
+    )
+    resolved_open_orders = (
+        data_dir / "raw" / "portfolio" / "open_orders.csv"
+        if open_orders_path == OPEN_ORDERS_PATH
+        else open_orders_path
+    )
+    resolved_market_dir = (
+        data_dir / "raw" / "market" if market_dir == DEFAULT_MARKET_DIR else market_dir
+    )
+    return resolved_positions, resolved_open_orders, resolved_market_dir
 
 
 def format_decision(inputs: DecisionInputs) -> str:
@@ -156,6 +227,8 @@ def format_decision(inputs: DecisionInputs) -> str:
 
     lines.append(f"Already holding: {_holding_sentence(traded, held_qty, position_value)}")
     lines.append(f"In cash: {_cash_sentence(inputs.cash)}")
+    if inputs.portfolio_state is not None:
+        lines.extend(["", *_portfolio_decision_lines(inputs, max_allocation)])
 
     lines.extend(["", "Ladder prices:"])
     if inputs.ladder:
@@ -178,6 +251,82 @@ def format_decision(inputs: DecisionInputs) -> str:
         lines.append("- None in existing reports.")
 
     return "\n".join(lines)
+
+
+def _portfolio_decision_lines(inputs: DecisionInputs, max_allocation: float | None) -> list[str]:
+    traded = inputs.traded_symbol.upper()
+    state = inputs.portfolio_state
+    if state is None:
+        return []
+    item = state.symbols.get(traded)
+    lines = ["Portfolio state:"]
+    if item is None:
+        lines.append(f"- Current {traded} position: 0 shares.")
+        lines.append("- Pending buy orders: none.")
+        lines.append("- Pending sell orders: none.")
+        lines.append("- Portfolio action: do not add orders.")
+        return lines
+
+    current_value = item.market_value or 0.0
+    allocation = item.allocation_pct
+    worst_value = current_value + item.pending_buy_value
+    worst_allocation = worst_value / inputs.account_value if inputs.account_value > 0 else None
+    max_dollars = inputs.account_value * max_allocation if max_allocation is not None else None
+    exceeds = max_dollars is not None and worst_value > max_dollars
+
+    lines.append(f"- Current {traded} position: {item.quantity:g} shares.")
+    if item.market_value is not None:
+        allocation_text = f" ({allocation:.1%})" if allocation is not None else ""
+        lines.append(
+            f"- Current {traded} market value: ${item.market_value:,.2f}{allocation_text}."
+        )
+    else:
+        lines.append(f"- Current {traded} market value: unavailable.")
+    lines.append(
+        f"- Pending buy orders: {item.pending_buy_quantity:g} shares, "
+        f"${item.pending_buy_value:,.2f}."
+    )
+    lines.append(
+        f"- Pending sell orders: {item.pending_sell_quantity:g} shares, "
+        f"${item.pending_sell_value:,.2f}."
+    )
+    worst_text = f" ({worst_allocation:.1%})" if worst_allocation is not None else ""
+    lines.append(f"- Worst-case if all buys fill: ${worst_value:,.2f}{worst_text}.")
+    if max_dollars is not None:
+        lines.append(
+            f"- Pending orders exceed max recommended allocation: {'YES' if exceeds else 'NO'}."
+        )
+    else:
+        lines.append("- Pending orders exceed max recommended allocation: unknown.")
+    lines.append(f"- Portfolio action: {_portfolio_action(inputs, item, exceeds)}.")
+    for warning in state.warnings:
+        lines.append(f"- Warning: {warning}")
+    return lines
+
+
+def _portfolio_action(
+    inputs: DecisionInputs,
+    item,
+    exceeds: bool,
+) -> str:
+    traded = inputs.traded_symbol.upper()
+    raw_action = inputs.summary.get("suggested_action", "NO_TRADE")
+    if exceeds:
+        return "cancel/reduce orders"
+    buy_allowed_actions = {
+        "WAIT_FOR_PULLBACK",
+        "TACTICAL_TQQQ_BUY_ALLOWED",
+        "SMALL_TQQQ_ALLOWED",
+    }
+    if item.pending_buy_value > 0 and raw_action in buy_allowed_actions:
+        return "keep orders"
+    if item.pending_buy_value > 0:
+        return "do not add orders"
+    if item.quantity > 0 and raw_action == "DEFENSIVE_OR_CASH":
+        return f"hold/trim existing {traded} position"
+    if item.quantity > 0:
+        return f"hold/trim existing {traded} position"
+    return "do not add orders"
 
 
 def _parse_summary(text: str) -> tuple[dict[str, str], list[str], list[str], list[str]]:

--- a/src/trading_lab/decision.py
+++ b/src/trading_lab/decision.py
@@ -15,6 +15,11 @@ from trading_lab.portfolio.state import (
     build_portfolio_state,
     portfolio_files_exist,
 )
+from trading_lab.portfolio.review import (
+    review_holdings,
+    review_open_orders,
+    summarize_order_reviews,
+)
 
 
 MISSING_REPORTS_MESSAGE = "Missing reports. Run ./scripts/tl_full_daily.sh first."
@@ -252,6 +257,8 @@ def format_decision(inputs: DecisionInputs) -> str:
     lines.append(f"In cash: {_cash_sentence(inputs.cash)}")
     if inputs.portfolio_state is not None:
         lines.extend(["", *_portfolio_decision_lines(inputs, max_allocation)])
+        lines.extend(["", *_portfolio_holdings_review_lines(inputs)])
+        lines.extend(["", *_open_order_review_lines(inputs, max_allocation)])
 
     lines.extend(["", "Ladder prices:"])
     if inputs.ladder:
@@ -350,6 +357,70 @@ def _portfolio_action(
     if item.quantity > 0:
         return f"hold/trim existing {traded} position"
     return "do not add orders"
+
+
+def _portfolio_holdings_review_lines(inputs: DecisionInputs) -> list[str]:
+    state = inputs.portfolio_state
+    if state is None:
+        return []
+    reviews = review_holdings(state, inputs.traded_symbol)
+    lines = ["Portfolio holdings review:"]
+    if not reviews:
+        lines.append("- No non-traded holdings to review.")
+        return lines
+    for row in reviews:
+        value = _format_money(row.value)
+        allocation = _format_pct(row.allocation)
+        lines.append(
+            f"- {row.symbol}: qty {row.quantity:g}, value {value}, "
+            f"allocation {allocation}, price {row.price_status}, status {row.status}."
+        )
+    lines.append("- No model-backed predictions are claimed for non-traded holdings.")
+    return lines
+
+
+def _open_order_review_lines(
+    inputs: DecisionInputs,
+    max_allocation: float | None,
+) -> list[str]:
+    state = inputs.portfolio_state
+    if state is None:
+        return []
+    reviews = review_open_orders(
+        state,
+        inputs.traded_symbol,
+        account_value=inputs.account_value,
+        max_allocation=max_allocation,
+        suggested_action=inputs.summary.get("suggested_action", "NO_TRADE"),
+        strategy_eligible=inputs.summary.get("strategy_eligible", "").upper() == "YES",
+        ladder=inputs.ladder,
+    )
+    summary = summarize_order_reviews(reviews)
+    lines = ["Open-order review:"]
+    lines.append(f"- Total pending buy notional: {_format_money(summary.total_pending_buy_notional)}.")
+    lines.append(f"- Total pending sell notional: {_format_money(summary.total_pending_sell_notional)}.")
+    lines.append(f"- Orders to cancel/reduce/review: {summary.cancel_reduce_review_count}.")
+    if summary.top_actions:
+        lines.append("- Top order actions:")
+        for row in summary.top_actions:
+            lines.append(
+                f"  - {row.recommended_action} {row.side} {row.symbol} "
+                f"{row.quantity:g} @ {_format_money(row.limit_price)}: {row.reason}"
+            )
+    if not reviews:
+        lines.append("- No local open orders found.")
+        return lines
+    lines.append("- Order details:")
+    for row in reviews:
+        projected = _format_money(row.projected_exposure)
+        lines.append(
+            f"  - {row.recommended_action} {row.symbol} {row.side} "
+            f"{row.quantity:g} @ {_format_money(row.limit_price)} "
+            f"({_format_money(row.notional)}, status {row.status}, "
+            f"{row.price_relation}, ladder {row.ladder_relation}, "
+            f"projected exposure {projected}): {row.reason}"
+        )
+    return lines
 
 
 def _parse_summary(text: str) -> tuple[dict[str, str], list[str], list[str], list[str]]:
@@ -507,6 +578,18 @@ def _cash_sentence(cash: float | None) -> str:
     if cash is None:
         return "cash not supplied."
     return f"yes, ${cash:,.2f} supplied." if cash > 0 else "no cash supplied."
+
+
+def _format_money(value: float | None) -> str:
+    if value is None:
+        return "unavailable"
+    return f"${value:,.2f}"
+
+
+def _format_pct(value: float | None) -> str:
+    if value is None:
+        return "unknown"
+    return f"{value:.1%}"
 
 
 def _float_or_none(value: str | None) -> float | None:

--- a/src/trading_lab/decision.py
+++ b/src/trading_lab/decision.py
@@ -16,8 +16,11 @@ from trading_lab.portfolio.state import (
     portfolio_files_exist,
 )
 from trading_lab.portfolio.review import (
+    advice_lines,
+    exposure_context,
     review_holdings,
     review_open_orders,
+    suggested_order_ideas,
     summarize_order_reviews,
 )
 
@@ -257,6 +260,7 @@ def format_decision(inputs: DecisionInputs) -> str:
     lines.append(f"In cash: {_cash_sentence(inputs.cash)}")
     if inputs.portfolio_state is not None:
         lines.extend(["", *_portfolio_decision_lines(inputs, max_allocation)])
+        lines.extend(["", *_advice_lines(inputs, action, max_allocation)])
         lines.extend(["", *_portfolio_holdings_review_lines(inputs)])
         lines.extend(["", *_open_order_review_lines(inputs, max_allocation)])
 
@@ -420,6 +424,44 @@ def _open_order_review_lines(
             f"{row.price_relation}, ladder {row.ladder_relation}, "
             f"projected exposure {projected}): {row.reason}"
         )
+    return lines
+
+
+def _advice_lines(
+    inputs: DecisionInputs,
+    action: str,
+    max_allocation: float | None,
+) -> list[str]:
+    state = inputs.portfolio_state
+    if state is None:
+        return []
+    reviews = review_open_orders(
+        state,
+        inputs.traded_symbol,
+        account_value=inputs.account_value,
+        max_allocation=max_allocation,
+        suggested_action=inputs.summary.get("suggested_action", "NO_TRADE"),
+        strategy_eligible=inputs.summary.get("strategy_eligible", "").upper() == "YES",
+        ladder=inputs.ladder,
+    )
+    summary = summarize_order_reviews(reviews)
+    context = exposure_context(state, inputs.traded_symbol, inputs.account_value, max_allocation)
+    lines = ["Advice and Interpretation:"]
+    lines.extend(f"- {line}" for line in advice_lines(
+        state,
+        inputs.traded_symbol,
+        action=action,
+        max_exposure=context.max_exposure,
+        order_summary=summary,
+    ))
+    lines.extend(["", "Suggested order ideas:"])
+    lines.extend(f"- {line}" for line in suggested_order_ideas(
+        state,
+        inputs.traded_symbol,
+        context=context,
+        reviews=reviews,
+        ladder=inputs.ladder,
+    ))
     return lines
 
 

--- a/src/trading_lab/decision.py
+++ b/src/trading_lab/decision.py
@@ -62,6 +62,7 @@ def render_daily_decision(
     positions: list[str] | tuple[str, ...] | None = None,
     positions_path: Path = POSITIONS_PATH,
     open_orders_path: Path = OPEN_ORDERS_PATH,
+    account_path: Path | None = None,
     market_dir: Path = DEFAULT_MARKET_DIR,
 ) -> str:
     """Render a fast read-only daily decision from existing report files."""
@@ -75,6 +76,7 @@ def render_daily_decision(
         positions=positions,
         positions_path=positions_path,
         open_orders_path=open_orders_path,
+        account_path=account_path,
         market_dir=market_dir,
     )
     if inputs is None:
@@ -92,6 +94,7 @@ def load_decision_inputs(
     positions: list[str] | tuple[str, ...] | None = None,
     positions_path: Path = POSITIONS_PATH,
     open_orders_path: Path = OPEN_ORDERS_PATH,
+    account_path: Path | None = None,
     market_dir: Path = DEFAULT_MARKET_DIR,
 ) -> DecisionInputs | None:
     _ = manual_dir
@@ -125,10 +128,13 @@ def load_decision_inputs(
         local_portfolio = build_portfolio_state(
             positions_path=positions_path,
             open_orders_path=open_orders_path,
+            **({"account_path": account_path} if account_path is not None else {}),
             market_dir=market_dir,
-            account_value=resolved_account_value,
+            account_value=account_value,
             cash=cash,
         )
+        if local_portfolio.account_value is not None:
+            resolved_account_value = float(local_portfolio.account_value)
 
     if local_portfolio is not None:
         parsed_positions = tuple(

--- a/src/trading_lab/portfolio/__init__.py
+++ b/src/trading_lab/portfolio/__init__.py
@@ -1,0 +1,2 @@
+"""Local read-only portfolio state helpers."""
+

--- a/src/trading_lab/portfolio/gui.py
+++ b/src/trading_lab/portfolio/gui.py
@@ -26,6 +26,11 @@ from trading_lab.portfolio.state import (
     write_account_value,
     write_position,
 )
+from trading_lab.portfolio.review import (
+    review_holdings,
+    review_open_orders,
+    summarize_order_reviews,
+)
 
 
 def render_status_page() -> str:
@@ -35,6 +40,24 @@ def render_status_page() -> str:
     decision = _decision_view_model(decision_text, decision_inputs)
     traded_item = state.symbols.get(decision["traded_symbol"])
     metadata = _metadata(decision["traded_symbol"])
+    max_allocation = _percent(decision_inputs.summary.get("max_traded_allocation")) if decision_inputs else None
+    holding_reviews = (
+        review_holdings(state, decision_inputs.traded_symbol) if decision_inputs is not None else ()
+    )
+    order_reviews = (
+        review_open_orders(
+            state,
+            decision_inputs.traded_symbol,
+            account_value=decision_inputs.account_value,
+            max_allocation=max_allocation,
+            suggested_action=decision_inputs.summary.get("suggested_action", "NO_TRADE"),
+            strategy_eligible=decision_inputs.summary.get("strategy_eligible", "").upper() == "YES",
+            ladder=decision_inputs.ladder,
+        )
+        if decision_inputs is not None
+        else ()
+    )
+    order_summary = summarize_order_reviews(order_reviews)
 
     return f"""<!doctype html>
 <html>
@@ -65,7 +88,7 @@ def render_status_page() -> str:
     main {{ max-width: 1180px; margin: 0 auto; padding: 24px; }}
     header {{
       display: grid;
-      grid-template-columns: 1fr repeat(4, minmax(120px, auto));
+      grid-template-columns: 1fr repeat(5, minmax(120px, auto));
       gap: 12px;
       align-items: end;
       margin-bottom: 18px;
@@ -93,7 +116,23 @@ def render_status_page() -> str:
     .ok {{ color: var(--ok); }}
     table {{ width: 100%; border-collapse: collapse; margin-top: 8px; overflow: hidden; }}
     th, td {{ border-bottom: 1px solid var(--line); padding: 9px 8px; text-align: left; }}
-    th {{ color: var(--muted); font-weight: 600; background: rgba(255,255,255,.03); }}
+    th {{
+      color: var(--muted);
+      font-weight: 600;
+      background: #171123;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }}
+    .table-scroll {{
+      max-height: 360px;
+      overflow-y: auto;
+      resize: vertical;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      min-height: 230px;
+    }}
+    .table-scroll table {{ margin-top: 0; }}
     form {{
       display: grid;
       grid-template-columns: repeat(5, minmax(120px, 1fr));
@@ -129,11 +168,13 @@ def render_status_page() -> str:
       <h1>Trading Lab</h1>
       <div class="muted">Local decision dashboard. No broker connection.</div>
     </div>
-    {_header_metric("Local time", metadata["local_time"])}
+    {_header_metric("Local time", metadata["local_time"], value_id="local-clock")}
+    {_header_metric("Last local refresh", metadata["local_time"], value_id="last-refresh")}
     {_header_metric("Report date", metadata["report_date"])}
     {_header_metric("Account value", _money(state.account_value))}
     {_header_metric("Cash", _money(state.cash))}
   </header>
+  <p class="muted">Local dashboard refreshes hourly from existing files. Run tlfull to update market/model reports.</p>
 
   <section class="card">
     <h2>Daily decision</h2>
@@ -149,7 +190,11 @@ def render_status_page() -> str:
       {_metric("Max exposure", decision["max_exposure"])}
       {_metric("Buy capacity", decision["buy_capacity"])}
       {_metric("Portfolio action", decision["portfolio_action"])}
+      {_metric("Total buy orders", _money(order_summary.total_pending_buy_notional))}
+      {_metric("Total sell orders", _money(order_summary.total_pending_sell_notional))}
+      {_metric("Flagged orders", str(order_summary.cancel_reduce_review_count))}
     </div>
+    {_top_order_actions(order_summary.top_actions)}
     <p class="muted">Model probability: {escape(decision["probability"])} | Active target: {escape(decision["target"])}</p>
     {_blockers(decision["blockers"])}
   </section>
@@ -183,19 +228,44 @@ def render_status_page() -> str:
   </div>
 
   <section class="card">
+    <h2>Portfolio holdings review</h2>
+    <div class="table-scroll">
+      <table>
+        <tr><th>Symbol</th><th>Quantity</th><th>Value</th><th>Allocation</th><th>Price</th><th>Status</th></tr>
+        {_holding_review_rows(holding_reviews)}
+      </table>
+    </div>
+    <p class="muted">No model-backed buy/sell predictions are claimed for non-traded holdings.</p>
+  </section>
+
+  <section class="card">
+    <h2>Open-order recommendations</h2>
+    <div class="table-scroll">
+      <table>
+        <tr><th>Action</th><th>Symbol</th><th>Side</th><th>Qty</th><th>Limit</th><th>Notional</th><th>Status</th><th>Price</th><th>Ladder</th><th>Projected</th><th>Reason</th></tr>
+        {_order_review_rows(order_reviews)}
+      </table>
+    </div>
+  </section>
+
+  <section class="card">
     <h2>Positions</h2>
-    <table>
-      <tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>Value</th><th>Allocation</th><th>Updated</th></tr>
-      {_position_rows(state)}
-    </table>
+    <div class="table-scroll">
+      <table>
+        <tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>Value</th><th>Allocation</th><th>Updated</th></tr>
+        {_position_rows(state)}
+      </table>
+    </div>
   </section>
 
   <section class="card">
     <h2>Open orders</h2>
-    <table>
-      <tr><th>Symbol</th><th>Side</th><th>Type</th><th>Quantity</th><th>Limit</th><th>Notional</th><th>Status</th><th>Submitted</th></tr>
-      {_order_rows(state)}
-    </table>
+    <div class="table-scroll">
+      <table>
+        <tr><th>Symbol</th><th>Side</th><th>Type</th><th>Quantity</th><th>Limit</th><th>Notional</th><th>Status</th><th>Submitted</th></tr>
+        {_order_rows(state)}
+      </table>
+    </div>
   </section>
 
   <section class="card">
@@ -204,6 +274,20 @@ def render_status_page() -> str:
     {_forms()}
   </section>
 </main>
+<script>
+  function pad(n) {{ return String(n).padStart(2, '0'); }}
+  function formatLocalTime(d) {{
+    return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) +
+      ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds());
+  }}
+  function updateLocalClock() {{
+    var node = document.getElementById('local-clock');
+    if (node) {{ node.textContent = formatLocalTime(new Date()); }}
+  }}
+  updateLocalClock();
+  setInterval(updateLocalClock, 1000);
+  setTimeout(function () {{ window.location.reload(); }}, 60 * 60 * 1000);
+</script>
 </body>
 </html>
 """
@@ -408,6 +492,54 @@ def _order_rows(state) -> str:
     return "\n".join(rows) or "<tr><td colspan='8'>No local open orders.</td></tr>"
 
 
+def _holding_review_rows(rows) -> str:
+    out = []
+    for row in rows:
+        out.append(
+            "<tr>"
+            f"<td>{escape(row.symbol)}</td>"
+            f"<td>{row.quantity:g}</td>"
+            f"<td>{_money(row.value)}</td>"
+            f"<td>{_allocation(row.allocation)}</td>"
+            f"<td>{escape(row.price_status)}</td>"
+            f"<td>{escape(row.status)}</td>"
+            "</tr>"
+        )
+    return "\n".join(out) or "<tr><td colspan='6'>No non-traded holdings.</td></tr>"
+
+
+def _order_review_rows(rows) -> str:
+    out = []
+    for row in rows:
+        out.append(
+            "<tr>"
+            f"<td>{escape(row.recommended_action)}</td>"
+            f"<td>{escape(row.symbol)}</td>"
+            f"<td>{escape(row.side)}</td>"
+            f"<td>{row.quantity:g}</td>"
+            f"<td>{_money(row.limit_price)}</td>"
+            f"<td>{_money(row.notional)}</td>"
+            f"<td>{escape(row.status)}</td>"
+            f"<td>{escape(row.price_relation)}</td>"
+            f"<td>{escape(row.ladder_relation)}</td>"
+            f"<td>{_money(row.projected_exposure)}</td>"
+            f"<td>{escape(row.reason)}</td>"
+            "</tr>"
+        )
+    return "\n".join(out) or "<tr><td colspan='11'>No local open orders.</td></tr>"
+
+
+def _top_order_actions(rows) -> str:
+    if not rows:
+        return '<p class="ok">No cancel/reduce/review order actions.</p>'
+    items = "".join(
+        f"<li>{escape(row.recommended_action)} {escape(row.side)} {escape(row.symbol)} "
+        f"{row.quantity:g} @ {_money(row.limit_price)}: {escape(row.reason)}</li>"
+        for row in rows
+    )
+    return f'<div class="card warning"><h3>Top order actions</h3><ul>{items}</ul></div>'
+
+
 def _warnings(warnings: tuple[str, ...]) -> str:
     if not warnings:
         return '<p class="ok">All held symbols with quantities have known local prices.</p>'
@@ -426,8 +558,9 @@ def _metric(label: str, value: str) -> str:
     return f'<div class="metric"><span>{escape(label)}</span><strong>{escape(value)}</strong></div>'
 
 
-def _header_metric(label: str, value: str) -> str:
-    return f'<div class="metric"><span>{escape(label)}</span><strong>{escape(value)}</strong></div>'
+def _header_metric(label: str, value: str, value_id: str = "") -> str:
+    attr = f' id="{escape(value_id)}"' if value_id else ""
+    return f'<div class="metric"><span>{escape(label)}</span><strong{attr}>{escape(value)}</strong></div>'
 
 
 def _date_row(label: str, value: str) -> str:
@@ -459,6 +592,18 @@ def _report_date(path: Path) -> str:
         if line.startswith("Date:"):
             return line.split(":", 1)[1].strip()
     return "unknown"
+
+
+def _percent(value: str | None) -> float | None:
+    if value is None:
+        return None
+    text = value.strip()
+    try:
+        if text.endswith("%"):
+            return float(text[:-1]) / 100.0
+        return float(text)
+    except ValueError:
+        return None
 
 
 def _money(value: float | None) -> str:

--- a/src/trading_lab/portfolio/gui.py
+++ b/src/trading_lab/portfolio/gui.py
@@ -32,12 +32,14 @@ from trading_lab.portfolio.review import (
     review_open_orders,
     suggested_order_ideas,
     summarize_order_reviews,
+    normalize_risk_mode,
 )
 
 
-def render_status_page() -> str:
+def render_status_page(risk_mode: str = "conservative") -> str:
+    risk_mode = normalize_risk_mode(risk_mode)
     state = build_portfolio_state()
-    decision_inputs = load_decision_inputs()
+    decision_inputs = load_decision_inputs(risk_mode=risk_mode)
     decision_text = format_decision(decision_inputs) if decision_inputs is not None else ""
     decision = _decision_view_model(decision_text, decision_inputs)
     traded_item = state.symbols.get(decision["traded_symbol"])
@@ -55,6 +57,7 @@ def render_status_page() -> str:
             suggested_action=decision_inputs.summary.get("suggested_action", "NO_TRADE"),
             strategy_eligible=decision_inputs.summary.get("strategy_eligible", "").upper() == "YES",
             ladder=decision_inputs.ladder,
+            risk_mode=risk_mode,
         )
         if decision_inputs is not None
         else ()
@@ -77,6 +80,7 @@ def render_status_page() -> str:
             action=decision["action"],
             max_exposure=context.max_exposure if context is not None else None,
             order_summary=order_summary,
+            risk_mode=risk_mode,
         )
         if decision_inputs is not None
         else ()
@@ -88,6 +92,7 @@ def render_status_page() -> str:
             context=context,
             reviews=order_reviews,
             ladder=decision_inputs.ladder,
+            risk_mode=risk_mode,
         )
         if decision_inputs is not None and context is not None
         else ()
@@ -198,6 +203,13 @@ def render_status_page() -> str:
       padding-top: 12px;
       margin-top: 12px;
     }}
+    .risk-mode-form {{
+      display: block;
+      max-width: 260px;
+      border-top: 0;
+      padding-top: 0;
+      margin: 0 0 10px;
+    }}
     label {{ color: var(--muted); font-size: 12px; }}
     input, select, button {{
       width: 100%;
@@ -237,6 +249,15 @@ def render_status_page() -> str:
       {_header_metric("Account value", _money(state.account_value))}
       {_header_metric("Cash", _money(state.cash))}
     </header>
+    <form class="risk-mode-form" method="get" action="/">
+      <label>Risk mode
+        <select name="risk_mode" onchange="this.form.submit()">
+          {_risk_option("conservative", risk_mode)}
+          {_risk_option("balanced", risk_mode)}
+          {_risk_option("aggressive", risk_mode)}
+        </select>
+      </label>
+    </form>
     <p class="muted">Local dashboard refreshes hourly from existing files. Run tlfull to update market/model reports.</p>
 
     <section class="card tight">
@@ -253,6 +274,7 @@ def render_status_page() -> str:
         {_metric("Max exposure", decision["max_exposure"])}
         {_metric("Buy capacity", decision["buy_capacity"])}
         {_metric("Portfolio action", decision["portfolio_action"])}
+        {_metric("Risk mode", risk_mode)}
         {_metric("Total buy orders", _money(order_summary.total_pending_buy_notional))}
         {_metric("Total sell orders", _money(order_summary.total_pending_sell_notional))}
         {_metric("Flagged orders", str(order_summary.cancel_reduce_review_count))}
@@ -396,7 +418,9 @@ def apply_form_action(path: str, fields: dict[str, str]) -> str:
 def run_gui(host: str = "127.0.0.1", port: int = 8765) -> None:
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:
-            body = render_status_page().encode("utf-8")
+            query = parse_qs(self.path.split("?", 1)[1]) if "?" in self.path else {}
+            risk_mode = query.get("risk_mode", ["conservative"])[-1]
+            body = render_status_page(risk_mode=risk_mode).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
@@ -518,6 +542,11 @@ def _forms() -> str:
       <button type="submit" name="all" value="1">Clear all orders</button>
     </form>
     """
+
+
+def _risk_option(value: str, selected: str) -> str:
+    attr = " selected" if value == selected else ""
+    return f'<option value="{escape(value)}"{attr}>{escape(value)}</option>'
 
 
 def _position_rows(state) -> str:

--- a/src/trading_lab/portfolio/gui.py
+++ b/src/trading_lab/portfolio/gui.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+from datetime import datetime
 from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from urllib.parse import parse_qs
+import csv
 import webbrowser
 
+from trading_lab.decision import (
+    DEFAULT_REPORTS_DIR,
+    SUMMARY_FILE,
+    format_decision,
+    load_decision_inputs,
+)
 from trading_lab.portfolio.state import (
     ACCOUNT_PATH,
     OPEN_ORDERS_PATH,
@@ -21,85 +30,180 @@ from trading_lab.portfolio.state import (
 
 def render_status_page() -> str:
     state = build_portfolio_state()
-    position_rows = "\n".join(_position_row(item) for item in state.symbols.values())
-    if not position_rows:
-        position_rows = "<tr><td colspan='5'>No local positions or orders.</td></tr>"
-
-    order_rows = "\n".join(
-        "<tr>"
-        f"<td>{escape(order.symbol)}</td>"
-        f"<td>{escape(order.side)}</td>"
-        f"<td>{escape(order.type)}</td>"
-        f"<td>{order.quantity:g}</td>"
-        f"<td>{order.limit_price:.2f}</td>"
-        f"<td>{escape(order.status)}</td>"
-        "</tr>"
-        for order in state.open_orders
-    )
-    if not order_rows:
-        order_rows = "<tr><td colspan='6'>No local open orders.</td></tr>"
+    decision_inputs = load_decision_inputs()
+    decision_text = format_decision(decision_inputs) if decision_inputs is not None else ""
+    decision = _decision_view_model(decision_text, decision_inputs)
+    traded_item = state.symbols.get(decision["traded_symbol"])
+    metadata = _metadata(decision["traded_symbol"])
 
     return f"""<!doctype html>
 <html>
 <head>
   <meta charset="utf-8">
-  <title>trading-lab portfolio</title>
+  <title>Trading Lab Portfolio</title>
   <style>
-    body {{ font-family: system-ui, sans-serif; margin: 24px; max-width: 1100px; }}
-    table {{ border-collapse: collapse; width: 100%; margin: 12px 0 24px; }}
-    th, td {{ border: 1px solid #ccc; padding: 6px 8px; text-align: left; }}
-    form {{ border: 1px solid #ccc; padding: 12px; margin: 12px 0; }}
-    input, select, button {{ margin: 4px; }}
-    pre {{ background: #f6f6f6; padding: 12px; overflow: auto; }}
+    :root {{
+      color-scheme: dark;
+      --bg: #0b0711;
+      --panel: #16101f;
+      --panel-2: #1f1730;
+      --line: #35284c;
+      --text: #f4efff;
+      --muted: #b9abc9;
+      --accent: #b48cff;
+      --danger: #ff8fa3;
+      --ok: #7ee7b8;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      background: radial-gradient(circle at top left, #211333 0, var(--bg) 36%);
+      color: var(--text);
+      font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+      line-height: 1.4;
+    }}
+    main {{ max-width: 1180px; margin: 0 auto; padding: 24px; }}
+    header {{
+      display: grid;
+      grid-template-columns: 1fr repeat(4, minmax(120px, auto));
+      gap: 12px;
+      align-items: end;
+      margin-bottom: 18px;
+    }}
+    h1, h2, h3 {{ margin: 0; }}
+    h1 {{ font-size: 28px; }}
+    h2 {{ font-size: 18px; margin-bottom: 12px; }}
+    h3 {{ font-size: 14px; margin-bottom: 8px; color: var(--muted); }}
+    .muted {{ color: var(--muted); }}
+    .grid {{ display: grid; grid-template-columns: 1.3fr .9fr; gap: 16px; }}
+    .card {{
+      background: color-mix(in srgb, var(--panel) 94%, #6f42c1 6%);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+      box-shadow: 0 16px 50px rgba(0,0,0,.28);
+      margin-bottom: 16px;
+    }}
+    .metric-grid {{ display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }}
+    .metric {{ background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; padding: 10px; }}
+    .metric span {{ display: block; color: var(--muted); font-size: 12px; }}
+    .metric strong {{ display: block; margin-top: 3px; font-size: 16px; }}
+    .action {{ font-size: 40px; color: var(--accent); letter-spacing: 0; }}
+    .danger {{ color: var(--danger); }}
+    .ok {{ color: var(--ok); }}
+    table {{ width: 100%; border-collapse: collapse; margin-top: 8px; overflow: hidden; }}
+    th, td {{ border-bottom: 1px solid var(--line); padding: 9px 8px; text-align: left; }}
+    th {{ color: var(--muted); font-weight: 600; background: rgba(255,255,255,.03); }}
+    form {{
+      display: grid;
+      grid-template-columns: repeat(5, minmax(120px, 1fr));
+      gap: 8px;
+      border-top: 1px solid var(--line);
+      padding-top: 12px;
+      margin-top: 12px;
+    }}
+    label {{ color: var(--muted); font-size: 12px; }}
+    input, select, button {{
+      width: 100%;
+      margin-top: 4px;
+      border-radius: 6px;
+      border: 1px solid var(--line);
+      background: #0f0a17;
+      color: var(--text);
+      padding: 8px;
+    }}
+    button {{ background: #6f42c1; border-color: #8e62df; cursor: pointer; font-weight: 700; }}
+    .warning {{ border-color: #704155; color: #ffd3dc; background: #27121e; }}
+    .span-2 {{ grid-column: span 2; }}
+    .span-5 {{ grid-column: 1 / -1; }}
+    @media (max-width: 860px) {{
+      header, .grid, .metric-grid, form {{ grid-template-columns: 1fr; }}
+      .span-2, .span-5 {{ grid-column: auto; }}
+    }}
   </style>
 </head>
 <body>
-  <h1>Local portfolio</h1>
-  <p>Cash: {_money(state.cash)} | Account value: {_money(state.account_value)}</p>
-  <pre>{escape(summarize_portfolio_state(state))}</pre>
+<main>
+  <header>
+    <div>
+      <h1>Trading Lab</h1>
+      <div class="muted">Local decision dashboard. No broker connection.</div>
+    </div>
+    {_header_metric("Local time", metadata["local_time"])}
+    {_header_metric("Report date", metadata["report_date"])}
+    {_header_metric("Account value", _money(state.account_value))}
+    {_header_metric("Cash", _money(state.cash))}
+  </header>
 
-  <h2>Positions</h2>
-  <table>
-    <tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>Value</th><th>Allocation</th></tr>
-    {position_rows}
-  </table>
+  <section class="card">
+    <h2>Daily decision</h2>
+    <div class="action">{escape(decision["action"])}</div>
+    <p><strong>Now:</strong> {escape(decision["now"])}</p>
+    <p><strong>Decision:</strong> {escape(decision["sentence"])}</p>
+    <div class="metric-grid">
+      {_metric("Traded symbol", decision["traded_symbol"])}
+      {_metric("Current position", _quantity(traded_item.quantity if traded_item else 0))}
+      {_metric("Current allocation", _allocation(traded_item.allocation_pct if traded_item else None))}
+      {_metric("Pending buys", _money(traded_item.pending_buy_value if traded_item else 0))}
+      {_metric("Pending sells", _money(traded_item.pending_sell_value if traded_item else 0))}
+      {_metric("Max exposure", decision["max_exposure"])}
+      {_metric("Buy capacity", decision["buy_capacity"])}
+      {_metric("Portfolio action", decision["portfolio_action"])}
+    </div>
+    <p class="muted">Model probability: {escape(decision["probability"])} | Active target: {escape(decision["target"])}</p>
+    {_blockers(decision["blockers"])}
+  </section>
 
-  <h2>Open orders</h2>
-  <table>
-    <tr><th>Symbol</th><th>Side</th><th>Type</th><th>Quantity</th><th>Limit</th><th>Status</th></tr>
-    {order_rows}
-  </table>
+  <div class="grid">
+    <section class="card">
+      <h2>Portfolio summary</h2>
+      <div class="metric-grid">
+        {_metric("Total positions", str(len(state.positions)))}
+        {_metric("Open orders", str(len(state.open_orders)))}
+        {_metric("Known equity value", _money(state.total_market_value))}
+        {_metric("Cash", _money(state.cash))}
+        {_metric("Account value", _money(state.account_value))}
+        {_metric("Missing prices", str(len(state.warnings)))}
+      </div>
+      {_warnings(state.warnings)}
+    </section>
 
-  <h2>Edit local CSVs</h2>
-  <form method="post" action="/account">
-    <label>Cash <input name="cash" type="number" step="any"></label>
-    <label>Account value <input name="account_value" type="number" step="any"></label>
-    <button type="submit">Save account</button>
-  </form>
-  <form method="post" action="/position/set">
-    <label>Symbol <input name="symbol" required></label>
-    <label>Quantity <input name="quantity" type="number" step="any" required></label>
-    <button type="submit">Set position</button>
-  </form>
-  <form method="post" action="/position/update">
-    <select name="side"><option>buy</option><option>sell</option></select>
-    <label>Symbol <input name="symbol" required></label>
-    <label>Quantity <input name="quantity" type="number" step="any" required></label>
-    <label><input name="allow_negative" type="checkbox" value="1"> allow negative</label>
-    <button type="submit">Apply position update</button>
-  </form>
-  <form method="post" action="/order/add">
-    <select name="side"><option>buy</option><option>sell</option></select>
-    <label>Symbol <input name="symbol" required></label>
-    <label>Quantity <input name="quantity" type="number" step="any" required></label>
-    <label>Limit <input name="limit_price" type="number" step="any" required></label>
-    <button type="submit">Add limit order</button>
-  </form>
-  <form method="post" action="/order/clear">
-    <label>Symbol <input name="symbol"></label>
-    <button type="submit">Clear symbol orders</button>
-    <button type="submit" name="all" value="1">Clear all orders</button>
-  </form>
+    <section class="card">
+      <h2>Dates and updates</h2>
+      <table>
+        <tr><th>Item</th><th>Latest</th></tr>
+        {_date_row("positions.csv modified", metadata["positions_mtime"])}
+        {_date_row("open_orders.csv modified", metadata["orders_mtime"])}
+        {_date_row("account.csv modified", metadata["account_mtime"])}
+        {_date_row("Market CSV date", metadata["market_date"])}
+        {_date_row("Daily report date", metadata["report_date"])}
+      </table>
+      <p class="muted">If prices are stale or missing, run market update or the daily workflow.</p>
+    </section>
+  </div>
+
+  <section class="card">
+    <h2>Positions</h2>
+    <table>
+      <tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>Value</th><th>Allocation</th><th>Updated</th></tr>
+      {_position_rows(state)}
+    </table>
+  </section>
+
+  <section class="card">
+    <h2>Open orders</h2>
+    <table>
+      <tr><th>Symbol</th><th>Side</th><th>Type</th><th>Quantity</th><th>Limit</th><th>Notional</th><th>Status</th><th>Submitted</th></tr>
+      {_order_rows(state)}
+    </table>
+  </section>
+
+  <section class="card">
+    <h2>Edit local CSVs</h2>
+    <div class="card warning">Local CSV update only. This does not place, cancel, or modify broker orders.</div>
+    {_forms()}
+  </section>
+</main>
 </body>
 </html>
 """
@@ -140,19 +244,6 @@ def apply_form_action(path: str, fields: dict[str, str]) -> str:
         clear_open_orders(OPEN_ORDERS_PATH, None if fields.get("all") == "1" else symbol)
         return "cleared local orders"
     raise ValueError(f"Unknown form action: {path}")
-
-
-def _position_row(item) -> str:
-    allocation = f"{item.allocation_pct:.1%}" if item.allocation_pct is not None else "unknown"
-    return (
-        "<tr>"
-        f"<td>{escape(item.symbol)}</td>"
-        f"<td>{item.quantity:g}</td>"
-        f"<td>{_money(item.latest_price)}</td>"
-        f"<td>{_money(item.market_value)}</td>"
-        f"<td>{allocation}</td>"
-        "</tr>"
-    )
 
 
 def run_gui(host: str = "127.0.0.1", port: int = 8765) -> None:
@@ -198,7 +289,189 @@ def run_gui(host: str = "127.0.0.1", port: int = 8765) -> None:
         server.server_close()
 
 
+def _decision_view_model(decision_text: str, inputs) -> dict[str, object]:
+    lines = decision_text.splitlines()
+    selected = inputs.selected_signal if inputs is not None else {}
+    traded = inputs.traded_symbol if inputs is not None else "TQQQ"
+    blockers = list(inputs.blockers) if inputs is not None else []
+    target = ""
+    if inputs is not None:
+        target = inputs.summary.get("active_target_column") or inputs.summary.get("active_target_mode") or ""
+    return {
+        "action": _line_value(lines, "ACTION") or "NO REPORT",
+        "now": _line_value(lines, "Now") or "Reports are missing; run daily workflow when ready.",
+        "sentence": _line_value(lines, "Decision") or "No local decision report available.",
+        "traded_symbol": traded,
+        "max_exposure": _line_value(lines, f"Max {traded} exposure") or "unknown",
+        "buy_capacity": _line_value(lines, "Buy capacity now") or "unknown",
+        "portfolio_action": _portfolio_action_line(lines),
+        "probability": selected.get("probability", "unknown"),
+        "target": target or "unknown",
+        "blockers": blockers,
+    }
+
+
+def _line_value(lines: list[str], key: str) -> str:
+    prefix = f"{key}:"
+    for line in lines:
+        if line.startswith(prefix):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+def _portfolio_action_line(lines: list[str]) -> str:
+    for line in lines:
+        if line.startswith("- Portfolio action:"):
+            return line.split(":", 1)[1].strip().rstrip(".")
+    return "unknown"
+
+
+def _metadata(traded_symbol: str) -> dict[str, str]:
+    report_path = DEFAULT_REPORTS_DIR / SUMMARY_FILE
+    return {
+        "local_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "positions_mtime": _mtime(POSITIONS_PATH),
+        "orders_mtime": _mtime(OPEN_ORDERS_PATH),
+        "account_mtime": _mtime(ACCOUNT_PATH),
+        "market_date": _latest_csv_date(Path("data/raw/market") / f"{traded_symbol}.csv"),
+        "report_date": _report_date(report_path),
+    }
+
+
+def _forms() -> str:
+    return """
+    <form method="post" action="/account">
+      <label>Cash <input name="cash" type="number" step="any"></label>
+      <label>Account value <input name="account_value" type="number" step="any"></label>
+      <button type="submit">Save account</button>
+    </form>
+    <form method="post" action="/position/set">
+      <label>Symbol <input name="symbol" required></label>
+      <label>Quantity <input name="quantity" type="number" step="any" required></label>
+      <button type="submit">Set position</button>
+    </form>
+    <form method="post" action="/position/update">
+      <label>Side <select name="side"><option>buy</option><option>sell</option></select></label>
+      <label>Symbol <input name="symbol" required></label>
+      <label>Quantity <input name="quantity" type="number" step="any" required></label>
+      <label><input name="allow_negative" type="checkbox" value="1"> allow negative</label>
+      <button type="submit">Apply update</button>
+    </form>
+    <form method="post" action="/order/add">
+      <label>Side <select name="side"><option>buy</option><option>sell</option></select></label>
+      <label>Symbol <input name="symbol" required></label>
+      <label>Quantity <input name="quantity" type="number" step="any" required></label>
+      <label>Limit <input name="limit_price" type="number" step="any" required></label>
+      <button type="submit">Add limit order</button>
+    </form>
+    <form method="post" action="/order/clear">
+      <label>Symbol <input name="symbol"></label>
+      <button type="submit">Clear symbol orders</button>
+      <button type="submit" name="all" value="1">Clear all orders</button>
+    </form>
+    """
+
+
+def _position_rows(state) -> str:
+    rows = []
+    updated = {position.symbol: position.updated_at for position in state.positions}
+    for symbol in sorted(state.symbols):
+        item = state.symbols[symbol]
+        rows.append(
+            "<tr>"
+            f"<td>{escape(symbol)}</td>"
+            f"<td>{item.quantity:g}</td>"
+            f"<td>{_money(item.latest_price)}</td>"
+            f"<td>{_money(item.market_value)}</td>"
+            f"<td>{_allocation(item.allocation_pct)}</td>"
+            f"<td>{escape(updated.get(symbol, ''))}</td>"
+            "</tr>"
+        )
+    return "\n".join(rows) or "<tr><td colspan='6'>No local positions or orders.</td></tr>"
+
+
+def _order_rows(state) -> str:
+    rows = []
+    for order in state.open_orders:
+        rows.append(
+            "<tr>"
+            f"<td>{escape(order.symbol)}</td>"
+            f"<td>{escape(order.side)}</td>"
+            f"<td>{escape(order.type)}</td>"
+            f"<td>{order.quantity:g}</td>"
+            f"<td>{_money(order.limit_price)}</td>"
+            f"<td>{_money(order.exposure)}</td>"
+            f"<td>{escape(order.status)}</td>"
+            f"<td>{escape(order.submitted_at)}</td>"
+            "</tr>"
+        )
+    return "\n".join(rows) or "<tr><td colspan='8'>No local open orders.</td></tr>"
+
+
+def _warnings(warnings: tuple[str, ...]) -> str:
+    if not warnings:
+        return '<p class="ok">All held symbols with quantities have known local prices.</p>'
+    items = "".join(f"<li>{escape(warning)}</li>" for warning in warnings)
+    return f'<div class="card warning"><h3>Price warnings</h3><ul>{items}</ul></div>'
+
+
+def _blockers(blockers: list[str]) -> str:
+    if not blockers:
+        return '<p class="ok">No blockers in existing reports.</p>'
+    items = "".join(f"<li>{escape(blocker)}</li>" for blocker in blockers)
+    return f'<div class="card warning"><h3>Blockers</h3><ul>{items}</ul></div>'
+
+
+def _metric(label: str, value: str) -> str:
+    return f'<div class="metric"><span>{escape(label)}</span><strong>{escape(value)}</strong></div>'
+
+
+def _header_metric(label: str, value: str) -> str:
+    return f'<div class="metric"><span>{escape(label)}</span><strong>{escape(value)}</strong></div>'
+
+
+def _date_row(label: str, value: str) -> str:
+    return f"<tr><td>{escape(label)}</td><td>{escape(value)}</td></tr>"
+
+
+def _mtime(path: Path) -> str:
+    if not path.exists():
+        return "missing"
+    return datetime.fromtimestamp(path.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _latest_csv_date(path: Path) -> str:
+    if not path.exists():
+        return "missing"
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    for row in reversed(rows):
+        value = row.get("date", "").strip()
+        if value:
+            return value
+    return "unknown"
+
+
+def _report_date(path: Path) -> str:
+    if not path.exists():
+        return "missing"
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("Date:"):
+            return line.split(":", 1)[1].strip()
+    return "unknown"
+
+
 def _money(value: float | None) -> str:
     if value is None:
         return "unavailable"
     return f"${value:,.2f}"
+
+
+def _quantity(value: float | int) -> str:
+    return f"{value:g}"
+
+
+def _allocation(value: float | None) -> str:
+    if value is None:
+        return "unknown"
+    return f"{value:.1%}"

--- a/src/trading_lab/portfolio/gui.py
+++ b/src/trading_lab/portfolio/gui.py
@@ -36,8 +36,9 @@ from trading_lab.portfolio.review import (
 )
 
 
-def render_status_page(risk_mode: str = "conservative") -> str:
+def render_status_page(risk_mode: str = "conservative", active_tab: str = "daily") -> str:
     risk_mode = normalize_risk_mode(risk_mode)
+    active_tab = _normalize_tab(active_tab)
     state = build_portfolio_state()
     decision_inputs = load_decision_inputs(risk_mode=risk_mode)
     decision_text = format_decision(decision_inputs) if decision_inputs is not None else ""
@@ -125,12 +126,12 @@ def render_status_page(risk_mode: str = "conservative") -> str:
       line-height: 1.4;
     }}
     main {{ max-width: 1180px; margin: 0 auto; padding: 24px; }}
-    header {{
-      display: grid;
-      grid-template-columns: 1fr repeat(5, minmax(120px, auto));
-      gap: 12px;
+    .topbar {{
+      display: flex;
       align-items: end;
-      margin-bottom: 18px;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 14px;
     }}
     h1, h2, h3 {{ margin: 0; }}
     h1 {{ font-size: 28px; }}
@@ -181,7 +182,7 @@ def render_status_page(risk_mode: str = "conservative") -> str:
       min-height: 118px;
     }}
     .table-scroll table {{ margin-top: 0; }}
-    .tabs {{ display: flex; flex-wrap: wrap; gap: 8px; margin: 16px 0 12px; }}
+    .tabs {{ display: flex; flex-wrap: wrap; gap: 8px; }}
     .tab-button {{
       width: auto;
       margin: 0;
@@ -192,6 +193,40 @@ def render_status_page(risk_mode: str = "conservative") -> str:
     .tab-button.active {{ background: #6f42c1; color: var(--text); }}
     .tab-panel {{ display: none; }}
     .tab-panel.active {{ display: block; }}
+    .global-controls {{
+      display: grid;
+      grid-template-columns: minmax(260px, 1.4fr) repeat(5, minmax(120px, 1fr));
+      gap: 10px;
+      margin-bottom: 14px;
+    }}
+    .risk-control {{
+      background: var(--panel-2);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 9px;
+    }}
+    .risk-control span {{ display: block; color: var(--muted); font-size: 12px; }}
+    .risk-segmented {{
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 4px;
+      margin-top: 6px;
+      padding: 3px;
+      border: 1px solid #46335f;
+      border-radius: 999px;
+      background: #0f0a17;
+    }}
+    .risk-pill {{
+      width: 100%;
+      margin: 0;
+      padding: 7px 10px;
+      border-radius: 999px;
+      border: 0;
+      background: transparent;
+      color: var(--muted);
+      font-weight: 700;
+    }}
+    .risk-pill.active {{ background: #6f42c1; color: var(--text); }}
     .action-CANCEL, .action-REDUCE {{ color: var(--danger); font-weight: 700; }}
     .action-KEEP {{ color: var(--ok); font-weight: 700; }}
     .action-REVIEW, .action-MOVE_LOWER {{ color: #e5c07b; font-weight: 700; }}
@@ -202,13 +237,6 @@ def render_status_page(risk_mode: str = "conservative") -> str:
       border-top: 1px solid var(--line);
       padding-top: 12px;
       margin-top: 12px;
-    }}
-    .risk-mode-form {{
-      display: block;
-      max-width: 260px;
-      border-top: 0;
-      padding-top: 0;
-      margin: 0 0 10px;
     }}
     label {{ color: var(--muted); font-size: 12px; }}
     input, select, button {{
@@ -225,39 +253,42 @@ def render_status_page(risk_mode: str = "conservative") -> str:
     .span-2 {{ grid-column: span 2; }}
     .span-5 {{ grid-column: 1 / -1; }}
     @media (max-width: 860px) {{
-      header, .grid, .metric-grid, form {{ grid-template-columns: 1fr; }}
+      .topbar {{ align-items: start; flex-direction: column; }}
+      .global-controls, .grid, .metric-grid, form {{ grid-template-columns: 1fr; }}
       .span-2, .span-5 {{ grid-column: auto; }}
     }}
   </style>
 </head>
 <body>
 <main>
-  <h1>Trading Lab</h1>
-  <div class="muted">Local decision dashboard. No broker connection.</div>
-  <nav class="tabs" aria-label="Dashboard tabs">
-    <button class="tab-button active" type="button" data-tab="daily">Daily</button>
-    <button class="tab-button" type="button" data-tab="positions">Positions</button>
-    <button class="tab-button" type="button" data-tab="orders">Open orders</button>
-    <button class="tab-button" type="button" data-tab="edit">Edit local CSVs</button>
-  </nav>
-
-  <section class="tab-panel active" id="tab-daily">
-    <header>
-      {_header_metric("Local time", metadata["local_time"], value_id="local-clock")}
-      {_header_metric("Last local refresh", metadata["local_time"], value_id="last-refresh")}
-      {_header_metric("Report updated", metadata["report_updated"])}
-      {_header_metric("Account value", _money(state.account_value))}
-      {_header_metric("Cash", _money(state.cash))}
-    </header>
-    <form class="risk-mode-form" method="get" action="/">
-      <label>Risk mode
-        <select name="risk_mode" onchange="this.form.submit()">
-          {_risk_option("conservative", risk_mode)}
-          {_risk_option("balanced", risk_mode)}
-          {_risk_option("aggressive", risk_mode)}
-        </select>
-      </label>
-    </form>
+  <div class="topbar">
+    <div>
+      <h1>Trading Lab</h1>
+      <div class="muted">Local decision dashboard. No broker connection.</div>
+    </div>
+    <nav class="tabs" aria-label="Dashboard tabs">
+      {_tab_button("daily", "Daily", active_tab)}
+      {_tab_button("positions", "Positions", active_tab)}
+      {_tab_button("orders", "Open orders", active_tab)}
+      {_tab_button("edit", "Edit local CSVs", active_tab)}
+    </nav>
+  </div>
+  <section class="global-controls" aria-label="Global dashboard controls">
+    <div class="risk-control">
+      <span>Risk mode</span>
+      <div class="risk-segmented" role="radiogroup" aria-label="Risk mode">
+        {_risk_pill("conservative", risk_mode)}
+        {_risk_pill("balanced", risk_mode)}
+        {_risk_pill("aggressive", risk_mode)}
+      </div>
+    </div>
+    {_header_metric("Local time", metadata["local_time"], value_id="local-clock")}
+    {_header_metric("Last local refresh", metadata["local_time"], value_id="last-refresh")}
+    {_header_metric("Report updated", metadata["report_updated"])}
+    {_header_metric("Account value", _money(state.account_value))}
+    {_header_metric("Cash", _money(state.cash))}
+  </section>
+  <section class="{_tab_panel_class("daily", active_tab)}" id="tab-daily">
     <p class="muted">Local dashboard refreshes hourly from existing files. Run tlfull to update market/model reports.</p>
 
     <section class="card tight">
@@ -316,7 +347,7 @@ def render_status_page(risk_mode: str = "conservative") -> str:
     </div>
   </section>
 
-  <section class="tab-panel" id="tab-positions">
+  <section class="{_tab_panel_class("positions", active_tab)}" id="tab-positions">
     <section class="card">
       <h2>Positions</h2>
       <p class="muted">No model-backed buy/sell predictions are claimed for non-traded holdings.</p>
@@ -330,7 +361,7 @@ def render_status_page(risk_mode: str = "conservative") -> str:
     </section>
   </section>
 
-  <section class="tab-panel" id="tab-orders">
+  <section class="{_tab_panel_class("orders", active_tab)}" id="tab-orders">
     <section class="card">
       <h2>Open orders</h2>
       <div class="table-scroll">
@@ -342,7 +373,7 @@ def render_status_page(risk_mode: str = "conservative") -> str:
     </section>
   </section>
 
-  <section class="tab-panel" id="tab-edit">
+  <section class="{_tab_panel_class("edit", active_tab)}" id="tab-edit">
     <section class="card">
       <h2>Edit local CSVs</h2>
       <div class="card warning">Local CSV update only. This does not place, cancel, or modify broker orders.</div>
@@ -363,15 +394,75 @@ def render_status_page(risk_mode: str = "conservative") -> str:
   updateLocalClock();
   setInterval(updateLocalClock, 1000);
   setTimeout(function () {{ window.location.reload(); }}, 60 * 60 * 1000);
+  var dashboardState = {{
+    tab: {active_tab!r},
+    riskMode: {risk_mode!r}
+  }};
+  function params() {{ return new URLSearchParams(window.location.search); }}
+  function storeState() {{
+    try {{
+      localStorage.setItem('tlPortfolioTab', dashboardState.tab);
+      localStorage.setItem('tlPortfolioRiskMode', dashboardState.riskMode);
+    }} catch (error) {{}}
+  }}
+  function updateUrl(replace) {{
+    var search = params();
+    search.set('tab', dashboardState.tab);
+    search.set('risk_mode', dashboardState.riskMode);
+    var next = window.location.pathname + '?' + search.toString();
+    if (replace) {{ history.replaceState(null, '', next); }}
+    else {{ window.location.assign(next); }}
+  }}
+  function activateTab(tab) {{
+    dashboardState.tab = tab;
+    document.querySelectorAll('.tab-button').forEach(function (node) {{
+      node.classList.toggle('active', node.dataset.tab === tab);
+    }});
+    document.querySelectorAll('.tab-panel').forEach(function (node) {{
+      node.classList.toggle('active', node.id === 'tab-' + tab);
+    }});
+    storeState();
+    updateUrl(true);
+  }}
+  function hydrateState() {{
+    var search = params();
+    var urlRiskMode = search.get('risk_mode');
+    try {{
+      dashboardState.tab = search.get('tab') || localStorage.getItem('tlPortfolioTab') || dashboardState.tab;
+      dashboardState.riskMode = urlRiskMode || localStorage.getItem('tlPortfolioRiskMode') || dashboardState.riskMode;
+    }} catch (error) {{
+      dashboardState.tab = search.get('tab') || dashboardState.tab;
+      dashboardState.riskMode = urlRiskMode || dashboardState.riskMode;
+    }}
+    if (!document.getElementById('tab-' + dashboardState.tab)) {{ dashboardState.tab = 'daily'; }}
+    if (!document.querySelector('[data-risk-mode="' + dashboardState.riskMode + '"]')) {{
+      dashboardState.riskMode = {risk_mode!r};
+    }}
+    if (!urlRiskMode && dashboardState.riskMode !== {risk_mode!r}) {{
+      storeState();
+      updateUrl(false);
+      return;
+    }}
+    document.querySelectorAll('.risk-pill').forEach(function (node) {{
+      var isActive = node.dataset.riskMode === dashboardState.riskMode;
+      node.classList.toggle('active', isActive);
+      node.setAttribute('aria-checked', isActive ? 'true' : 'false');
+    }});
+    activateTab(dashboardState.tab);
+  }}
   document.querySelectorAll('.tab-button').forEach(function (button) {{
     button.addEventListener('click', function () {{
-      document.querySelectorAll('.tab-button').forEach(function (node) {{ node.classList.remove('active'); }});
-      document.querySelectorAll('.tab-panel').forEach(function (node) {{ node.classList.remove('active'); }});
-      button.classList.add('active');
-      var panel = document.getElementById('tab-' + button.dataset.tab);
-      if (panel) {{ panel.classList.add('active'); }}
+      activateTab(button.dataset.tab);
     }});
   }});
+  document.querySelectorAll('.risk-pill').forEach(function (button) {{
+    button.addEventListener('click', function () {{
+      dashboardState.riskMode = button.dataset.riskMode;
+      storeState();
+      updateUrl(false);
+    }});
+  }});
+  hydrateState();
 </script>
 </body>
 </html>
@@ -420,7 +511,8 @@ def run_gui(host: str = "127.0.0.1", port: int = 8765) -> None:
         def do_GET(self) -> None:
             query = parse_qs(self.path.split("?", 1)[1]) if "?" in self.path else {}
             risk_mode = query.get("risk_mode", ["conservative"])[-1]
-            body = render_status_page(risk_mode=risk_mode).encode("utf-8")
+            active_tab = query.get("tab", ["daily"])[-1]
+            body = render_status_page(risk_mode=risk_mode, active_tab=active_tab).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
@@ -544,9 +636,31 @@ def _forms() -> str:
     """
 
 
-def _risk_option(value: str, selected: str) -> str:
-    attr = " selected" if value == selected else ""
-    return f'<option value="{escape(value)}"{attr}>{escape(value)}</option>'
+def _normalize_tab(value: str) -> str:
+    return value if value in {"daily", "positions", "orders", "edit"} else "daily"
+
+
+def _tab_button(value: str, label: str, active_tab: str) -> str:
+    active = " active" if value == active_tab else ""
+    return (
+        f'<button class="tab-button{active}" type="button" '
+        f'data-tab="{escape(value)}">{escape(label)}</button>'
+    )
+
+
+def _tab_panel_class(value: str, active_tab: str) -> str:
+    active = " active" if value == active_tab else ""
+    return f"tab-panel{active}"
+
+
+def _risk_pill(value: str, selected: str) -> str:
+    active = " active" if value == selected else ""
+    label = value.capitalize()
+    return (
+        f'<button class="risk-pill{active}" type="button" role="radio" '
+        f'aria-checked="{str(value == selected).lower()}" '
+        f'data-risk-mode="{escape(value)}">{escape(label)}</button>'
+    )
 
 
 def _position_rows(state) -> str:

--- a/src/trading_lab/portfolio/gui.py
+++ b/src/trading_lab/portfolio/gui.py
@@ -26,8 +26,11 @@ from trading_lab.portfolio.state import (
     write_position,
 )
 from trading_lab.portfolio.review import (
+    advice_lines,
+    exposure_context,
     review_holdings,
     review_open_orders,
+    suggested_order_ideas,
     summarize_order_reviews,
 )
 
@@ -57,6 +60,38 @@ def render_status_page() -> str:
         else ()
     )
     order_summary = summarize_order_reviews(order_reviews)
+    context = (
+        exposure_context(
+            state,
+            decision_inputs.traded_symbol,
+            decision_inputs.account_value,
+            max_allocation,
+        )
+        if decision_inputs is not None
+        else None
+    )
+    advice = (
+        advice_lines(
+            state,
+            decision_inputs.traded_symbol,
+            action=decision["action"],
+            max_exposure=context.max_exposure if context is not None else None,
+            order_summary=order_summary,
+        )
+        if decision_inputs is not None
+        else ()
+    )
+    ideas = (
+        suggested_order_ideas(
+            state,
+            decision_inputs.traded_symbol,
+            context=context,
+            reviews=order_reviews,
+            ladder=decision_inputs.ladder,
+        )
+        if decision_inputs is not None and context is not None
+        else ()
+    )
 
     return f"""<!doctype html>
 <html>
@@ -112,6 +147,9 @@ def render_status_page() -> str:
     .metric strong {{ display: block; margin-top: 2px; font-size: 15px; }}
     .action {{ font-size: 34px; color: var(--accent); letter-spacing: 0; line-height: 1; }}
     .tight p {{ margin: 8px 0; }}
+    .order-actions-card {{ margin-top: 14px; }}
+    .compact-list {{ margin: 8px 0 0; padding-left: 20px; }}
+    .compact-list li {{ margin: 4px 0; }}
     .danger {{ color: var(--danger); }}
     .ok {{ color: var(--ok); }}
     .review {{ color: #e5c07b; }}
@@ -195,7 +233,7 @@ def render_status_page() -> str:
     <header>
       {_header_metric("Local time", metadata["local_time"], value_id="local-clock")}
       {_header_metric("Last local refresh", metadata["local_time"], value_id="last-refresh")}
-      {_header_metric("Report date", metadata["report_date"])}
+      {_header_metric("Report updated", metadata["report_updated"])}
       {_header_metric("Account value", _money(state.account_value))}
       {_header_metric("Cash", _money(state.cash))}
     </header>
@@ -220,6 +258,7 @@ def render_status_page() -> str:
         {_metric("Flagged orders", str(order_summary.cancel_reduce_review_count))}
       </div>
       {_top_order_actions(order_summary.top_actions)}
+      {_advice_card(advice)}
       <p class="muted">Model probability: {escape(decision["probability"])} | Active target: {escape(decision["target"])}</p>
       {_blockers(decision["blockers"])}
     </section>
@@ -247,7 +286,7 @@ def render_status_page() -> str:
             {_date_row("open_orders.csv modified", metadata["orders_mtime"])}
             {_date_row("account.csv modified", metadata["account_mtime"])}
             {_date_row("Market CSV date", metadata["market_date"])}
-            {_date_row("Daily report date", metadata["report_date"])}
+            {_date_row("Daily report date", metadata["report_updated"])}
           </table>
         </div>
         <p class="muted">If prices are stale or missing, run market update or tlfull.</p>
@@ -265,6 +304,7 @@ def render_status_page() -> str:
           {_position_review_rows(state, holding_reviews, decision["traded_symbol"])}
         </table>
       </div>
+      {_ideas_card(ideas)}
     </section>
   </section>
 
@@ -442,6 +482,7 @@ def _metadata(traded_symbol: str) -> dict[str, str]:
         "account_mtime": _mtime(ACCOUNT_PATH),
         "market_date": _latest_csv_date(Path("data/raw/market") / f"{traded_symbol}.csv"),
         "report_date": _report_date(report_path),
+        "report_updated": _report_updated(report_path),
     }
 
 
@@ -615,7 +656,31 @@ def _top_order_actions(rows) -> str:
         f"{row.quantity:g} @ {_money(row.limit_price)}: {escape(row.reason)}</li>"
         for row in rows
     )
-    return f'<div class="card warning"><h3>Top order actions</h3><ul>{items}</ul></div>'
+    return (
+        '<div class="card warning order-actions-card"><h3>Top order actions</h3>'
+        f'<ul class="compact-list">{items}</ul></div>'
+    )
+
+
+def _advice_card(lines) -> str:
+    if not lines:
+        return ""
+    items = "".join(f"<li>{escape(line)}</li>" for line in lines)
+    return (
+        '<div class="card order-actions-card"><h3>Advice and Interpretation</h3>'
+        f'<ul class="compact-list">{items}</ul></div>'
+    )
+
+
+def _ideas_card(lines) -> str:
+    if not lines:
+        return ""
+    items = "".join(f"<li>{escape(line)}</li>" for line in lines)
+    return (
+        '<div class="card order-actions-card"><h3>Suggested order ideas</h3>'
+        '<p class="muted">Local advice only. These are not broker actions.</p>'
+        f'<ul class="compact-list">{items}</ul></div>'
+    )
 
 
 def _warnings(warnings: tuple[str, ...]) -> str:
@@ -670,6 +735,12 @@ def _report_date(path: Path) -> str:
         if line.startswith("Date:"):
             return line.split(":", 1)[1].strip()
     return "unknown"
+
+
+def _report_updated(path: Path) -> str:
+    if path.exists():
+        return datetime.fromtimestamp(path.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
+    return _report_date(path)
 
 
 def _percent(value: str | None) -> float | None:

--- a/src/trading_lab/portfolio/gui.py
+++ b/src/trading_lab/portfolio/gui.py
@@ -171,7 +171,7 @@ def render_status_page(risk_mode: str = "conservative", active_tab: str = "daily
     }}
     .table-scroll {{
       max-height: 360px;
-      overflow-y: auto;
+      overflow: auto;
       resize: vertical;
       border: 1px solid var(--line);
       border-radius: 8px;
@@ -195,7 +195,7 @@ def render_status_page(risk_mode: str = "conservative", active_tab: str = "daily
     .tab-panel.active {{ display: block; }}
     .global-controls {{
       display: grid;
-      grid-template-columns: minmax(260px, 1.4fr) repeat(5, minmax(120px, 1fr));
+      grid-template-columns: minmax(340px, 1.35fr) repeat(5, minmax(120px, 1fr));
       gap: 10px;
       margin-bottom: 14px;
     }}
@@ -204,11 +204,13 @@ def render_status_page(risk_mode: str = "conservative", active_tab: str = "daily
       border: 1px solid var(--line);
       border-radius: 8px;
       padding: 9px;
+      min-width: 320px;
+      max-width: 420px;
     }}
     .risk-control span {{ display: block; color: var(--muted); font-size: 12px; }}
     .risk-segmented {{
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
+      display: flex;
+      flex-wrap: wrap;
       gap: 4px;
       margin-top: 6px;
       padding: 3px;
@@ -217,7 +219,8 @@ def render_status_page(risk_mode: str = "conservative", active_tab: str = "daily
       background: #0f0a17;
     }}
     .risk-pill {{
-      width: 100%;
+      width: auto;
+      flex: 1 1 auto;
       margin: 0;
       padding: 7px 10px;
       border-radius: 999px;
@@ -225,8 +228,34 @@ def render_status_page(risk_mode: str = "conservative", active_tab: str = "daily
       background: transparent;
       color: var(--muted);
       font-weight: 700;
+      text-align: center;
+      white-space: nowrap;
     }}
     .risk-pill.active {{ background: #6f42c1; color: var(--text); }}
+    .open-orders-table {{
+      min-width: 1500px;
+      table-layout: fixed;
+    }}
+    .open-orders-table th,
+    .open-orders-table td {{
+      vertical-align: top;
+    }}
+    .open-orders-table .col-recommendation {{ width: 120px; }}
+    .open-orders-table .col-symbol {{ width: 80px; }}
+    .open-orders-table .col-side {{ width: 72px; }}
+    .open-orders-table .col-type {{ width: 72px; }}
+    .open-orders-table .col-quantity {{ width: 86px; }}
+    .open-orders-table .col-money {{ width: 105px; }}
+    .open-orders-table .col-status {{ width: 90px; }}
+    .open-orders-table .col-submitted {{ width: 112px; }}
+    .open-orders-table .col-relation {{ width: 150px; }}
+    .open-orders-table .col-projected {{ width: 132px; }}
+    .open-orders-table .col-reason {{ width: 420px; }}
+    .open-orders-table .reason-cell {{
+      min-width: 420px;
+      white-space: normal;
+      line-height: 1.35;
+    }}
     .action-CANCEL, .action-REDUCE {{ color: var(--danger); font-weight: 700; }}
     .action-KEEP {{ color: var(--ok); font-weight: 700; }}
     .action-REVIEW, .action-MOVE_LOWER {{ color: #e5c07b; font-weight: 700; }}
@@ -255,6 +284,7 @@ def render_status_page(risk_mode: str = "conservative", active_tab: str = "daily
     @media (max-width: 860px) {{
       .topbar {{ align-items: start; flex-direction: column; }}
       .global-controls, .grid, .metric-grid, form {{ grid-template-columns: 1fr; }}
+      .risk-control {{ max-width: none; width: 100%; }}
       .span-2, .span-5 {{ grid-column: auto; }}
     }}
   </style>
@@ -365,7 +395,22 @@ def render_status_page(risk_mode: str = "conservative", active_tab: str = "daily
     <section class="card">
       <h2>Open orders</h2>
       <div class="table-scroll">
-        <table>
+        <table class="open-orders-table">
+          <colgroup>
+            <col class="col-recommendation">
+            <col class="col-symbol">
+            <col class="col-side">
+            <col class="col-type">
+            <col class="col-quantity">
+            <col class="col-money">
+            <col class="col-money">
+            <col class="col-status">
+            <col class="col-submitted">
+            <col class="col-relation">
+            <col class="col-relation">
+            <col class="col-projected">
+            <col class="col-reason">
+          </colgroup>
           <tr><th>Recommendation</th><th>Symbol</th><th>Side</th><th>Type</th><th>Quantity</th><th>Limit</th><th>Notional</th><th>Status</th><th>Submitted</th><th>Price relation</th><th>Ladder relation</th><th>Projected exposure</th><th>Reason</th></tr>
           {_combined_order_rows(state, order_reviews)}
         </table>
@@ -748,7 +793,7 @@ def _combined_order_rows(state, reviews) -> str:
             f"<td>{escape(review.price_relation)}</td>"
             f"<td>{escape(review.ladder_relation)}</td>"
             f"<td>{_money(review.projected_exposure)}</td>"
-            f"<td>{escape(review.reason)}</td>"
+            f"<td class=\"reason-cell\">{escape(review.reason)}</td>"
             "</tr>"
         )
     return "\n".join(rows) or "<tr><td colspan='13'>No local open orders.</td></tr>"

--- a/src/trading_lab/portfolio/gui.py
+++ b/src/trading_lab/portfolio/gui.py
@@ -21,7 +21,6 @@ from trading_lab.portfolio.state import (
     append_open_order,
     build_portfolio_state,
     clear_open_orders,
-    summarize_portfolio_state,
     update_position_quantity,
     write_account_value,
     write_position,
@@ -98,22 +97,24 @@ def render_status_page() -> str:
     h2 {{ font-size: 18px; margin-bottom: 12px; }}
     h3 {{ font-size: 14px; margin-bottom: 8px; color: var(--muted); }}
     .muted {{ color: var(--muted); }}
-    .grid {{ display: grid; grid-template-columns: 1.3fr .9fr; gap: 16px; }}
+    .grid {{ display: grid; grid-template-columns: 1.2fr .8fr; gap: 12px; }}
     .card {{
       background: color-mix(in srgb, var(--panel) 94%, #6f42c1 6%);
       border: 1px solid var(--line);
       border-radius: 8px;
-      padding: 16px;
+      padding: 14px;
       box-shadow: 0 16px 50px rgba(0,0,0,.28);
-      margin-bottom: 16px;
+      margin-bottom: 12px;
     }}
-    .metric-grid {{ display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }}
-    .metric {{ background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; padding: 10px; }}
+    .metric-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); gap: 8px; }}
+    .metric {{ background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; padding: 9px; }}
     .metric span {{ display: block; color: var(--muted); font-size: 12px; }}
-    .metric strong {{ display: block; margin-top: 3px; font-size: 16px; }}
-    .action {{ font-size: 40px; color: var(--accent); letter-spacing: 0; }}
+    .metric strong {{ display: block; margin-top: 2px; font-size: 15px; }}
+    .action {{ font-size: 34px; color: var(--accent); letter-spacing: 0; line-height: 1; }}
+    .tight p {{ margin: 8px 0; }}
     .danger {{ color: var(--danger); }}
     .ok {{ color: var(--ok); }}
+    .review {{ color: #e5c07b; }}
     table {{ width: 100%; border-collapse: collapse; margin-top: 8px; overflow: hidden; }}
     th, td {{ border-bottom: 1px solid var(--line); padding: 9px 8px; text-align: left; }}
     th {{
@@ -132,7 +133,25 @@ def render_status_page() -> str:
       border-radius: 8px;
       min-height: 230px;
     }}
+    .mini-scroll {{
+      max-height: 138px;
+      min-height: 118px;
+    }}
     .table-scroll table {{ margin-top: 0; }}
+    .tabs {{ display: flex; flex-wrap: wrap; gap: 8px; margin: 16px 0 12px; }}
+    .tab-button {{
+      width: auto;
+      margin: 0;
+      padding: 9px 14px;
+      background: #120c1c;
+      color: var(--muted);
+    }}
+    .tab-button.active {{ background: #6f42c1; color: var(--text); }}
+    .tab-panel {{ display: none; }}
+    .tab-panel.active {{ display: block; }}
+    .action-CANCEL, .action-REDUCE {{ color: var(--danger); font-weight: 700; }}
+    .action-KEEP {{ color: var(--ok); font-weight: 700; }}
+    .action-REVIEW, .action-MOVE_LOWER {{ color: #e5c07b; font-weight: 700; }}
     form {{
       display: grid;
       grid-template-columns: repeat(5, minmax(120px, 1fr));
@@ -163,115 +182,110 @@ def render_status_page() -> str:
 </head>
 <body>
 <main>
-  <header>
-    <div>
-      <h1>Trading Lab</h1>
-      <div class="muted">Local decision dashboard. No broker connection.</div>
-    </div>
-    {_header_metric("Local time", metadata["local_time"], value_id="local-clock")}
-    {_header_metric("Last local refresh", metadata["local_time"], value_id="last-refresh")}
-    {_header_metric("Report date", metadata["report_date"])}
-    {_header_metric("Account value", _money(state.account_value))}
-    {_header_metric("Cash", _money(state.cash))}
-  </header>
-  <p class="muted">Local dashboard refreshes hourly from existing files. Run tlfull to update market/model reports.</p>
+  <h1>Trading Lab</h1>
+  <div class="muted">Local decision dashboard. No broker connection.</div>
+  <nav class="tabs" aria-label="Dashboard tabs">
+    <button class="tab-button active" type="button" data-tab="daily">Daily</button>
+    <button class="tab-button" type="button" data-tab="positions">Positions</button>
+    <button class="tab-button" type="button" data-tab="orders">Open orders</button>
+    <button class="tab-button" type="button" data-tab="edit">Edit local CSVs</button>
+  </nav>
 
-  <section class="card">
-    <h2>Daily decision</h2>
-    <div class="action">{escape(decision["action"])}</div>
-    <p><strong>Now:</strong> {escape(decision["now"])}</p>
-    <p><strong>Decision:</strong> {escape(decision["sentence"])}</p>
-    <div class="metric-grid">
-      {_metric("Traded symbol", decision["traded_symbol"])}
-      {_metric("Current position", _quantity(traded_item.quantity if traded_item else 0))}
-      {_metric("Current allocation", _allocation(traded_item.allocation_pct if traded_item else None))}
-      {_metric("Pending buys", _money(traded_item.pending_buy_value if traded_item else 0))}
-      {_metric("Pending sells", _money(traded_item.pending_sell_value if traded_item else 0))}
-      {_metric("Max exposure", decision["max_exposure"])}
-      {_metric("Buy capacity", decision["buy_capacity"])}
-      {_metric("Portfolio action", decision["portfolio_action"])}
-      {_metric("Total buy orders", _money(order_summary.total_pending_buy_notional))}
-      {_metric("Total sell orders", _money(order_summary.total_pending_sell_notional))}
-      {_metric("Flagged orders", str(order_summary.cancel_reduce_review_count))}
-    </div>
-    {_top_order_actions(order_summary.top_actions)}
-    <p class="muted">Model probability: {escape(decision["probability"])} | Active target: {escape(decision["target"])}</p>
-    {_blockers(decision["blockers"])}
-  </section>
+  <section class="tab-panel active" id="tab-daily">
+    <header>
+      {_header_metric("Local time", metadata["local_time"], value_id="local-clock")}
+      {_header_metric("Last local refresh", metadata["local_time"], value_id="last-refresh")}
+      {_header_metric("Report date", metadata["report_date"])}
+      {_header_metric("Account value", _money(state.account_value))}
+      {_header_metric("Cash", _money(state.cash))}
+    </header>
+    <p class="muted">Local dashboard refreshes hourly from existing files. Run tlfull to update market/model reports.</p>
 
-  <div class="grid">
-    <section class="card">
-      <h2>Portfolio summary</h2>
+    <section class="card tight">
+      <h2>Daily decision</h2>
+      <div class="action">{escape(decision["action"])}</div>
+      <p><strong>Now:</strong> {escape(decision["now"])}</p>
+      <p><strong>Decision:</strong> {escape(decision["sentence"])}</p>
       <div class="metric-grid">
-        {_metric("Total positions", str(len(state.positions)))}
-        {_metric("Open orders", str(len(state.open_orders)))}
-        {_metric("Known equity value", _money(state.total_market_value))}
-        {_metric("Cash", _money(state.cash))}
-        {_metric("Account value", _money(state.account_value))}
-        {_metric("Missing prices", str(len(state.warnings)))}
+        {_metric("Traded symbol", decision["traded_symbol"])}
+        {_metric("Current position", _quantity(traded_item.quantity if traded_item else 0))}
+        {_metric("Current allocation", _allocation(traded_item.allocation_pct if traded_item else None))}
+        {_metric("Pending buys", _money(traded_item.pending_buy_value if traded_item else 0))}
+        {_metric("Pending sells", _money(traded_item.pending_sell_value if traded_item else 0))}
+        {_metric("Max exposure", decision["max_exposure"])}
+        {_metric("Buy capacity", decision["buy_capacity"])}
+        {_metric("Portfolio action", decision["portfolio_action"])}
+        {_metric("Total buy orders", _money(order_summary.total_pending_buy_notional))}
+        {_metric("Total sell orders", _money(order_summary.total_pending_sell_notional))}
+        {_metric("Flagged orders", str(order_summary.cancel_reduce_review_count))}
       </div>
-      {_warnings(state.warnings)}
+      {_top_order_actions(order_summary.top_actions)}
+      <p class="muted">Model probability: {escape(decision["probability"])} | Active target: {escape(decision["target"])}</p>
+      {_blockers(decision["blockers"])}
     </section>
 
+    <div class="grid">
+      <section class="card">
+        <h2>Portfolio summary</h2>
+        <div class="metric-grid">
+          {_metric("Total positions", str(len(state.positions)))}
+          {_metric("Open orders", str(len(state.open_orders)))}
+          {_metric("Known equity value", _money(state.total_market_value))}
+          {_metric("Cash", _money(state.cash))}
+          {_metric("Account value", _money(state.account_value))}
+          {_metric("Missing prices", str(len(state.warnings)))}
+        </div>
+        {_warnings(state.warnings)}
+      </section>
+
+      <section class="card">
+        <h2>Dates and updates</h2>
+        <div class="table-scroll mini-scroll">
+          <table>
+            <tr><th>Item</th><th>Latest</th></tr>
+            {_date_row("positions.csv modified", metadata["positions_mtime"])}
+            {_date_row("open_orders.csv modified", metadata["orders_mtime"])}
+            {_date_row("account.csv modified", metadata["account_mtime"])}
+            {_date_row("Market CSV date", metadata["market_date"])}
+            {_date_row("Daily report date", metadata["report_date"])}
+          </table>
+        </div>
+        <p class="muted">If prices are stale or missing, run market update or tlfull.</p>
+      </section>
+    </div>
+  </section>
+
+  <section class="tab-panel" id="tab-positions">
     <section class="card">
-      <h2>Dates and updates</h2>
-      <table>
-        <tr><th>Item</th><th>Latest</th></tr>
-        {_date_row("positions.csv modified", metadata["positions_mtime"])}
-        {_date_row("open_orders.csv modified", metadata["orders_mtime"])}
-        {_date_row("account.csv modified", metadata["account_mtime"])}
-        {_date_row("Market CSV date", metadata["market_date"])}
-        {_date_row("Daily report date", metadata["report_date"])}
-      </table>
-      <p class="muted">If prices are stale or missing, run market update or the daily workflow.</p>
+      <h2>Positions</h2>
+      <p class="muted">No model-backed buy/sell predictions are claimed for non-traded holdings.</p>
+      <div class="table-scroll">
+        <table>
+          <tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>Value</th><th>Allocation</th><th>Updated</th><th>Review status</th><th>Review note</th></tr>
+          {_position_review_rows(state, holding_reviews, decision["traded_symbol"])}
+        </table>
+      </div>
     </section>
-  </div>
-
-  <section class="card">
-    <h2>Portfolio holdings review</h2>
-    <div class="table-scroll">
-      <table>
-        <tr><th>Symbol</th><th>Quantity</th><th>Value</th><th>Allocation</th><th>Price</th><th>Status</th></tr>
-        {_holding_review_rows(holding_reviews)}
-      </table>
-    </div>
-    <p class="muted">No model-backed buy/sell predictions are claimed for non-traded holdings.</p>
   </section>
 
-  <section class="card">
-    <h2>Open-order recommendations</h2>
-    <div class="table-scroll">
-      <table>
-        <tr><th>Action</th><th>Symbol</th><th>Side</th><th>Qty</th><th>Limit</th><th>Notional</th><th>Status</th><th>Price</th><th>Ladder</th><th>Projected</th><th>Reason</th></tr>
-        {_order_review_rows(order_reviews)}
-      </table>
-    </div>
+  <section class="tab-panel" id="tab-orders">
+    <section class="card">
+      <h2>Open orders</h2>
+      <div class="table-scroll">
+        <table>
+          <tr><th>Recommendation</th><th>Symbol</th><th>Side</th><th>Type</th><th>Quantity</th><th>Limit</th><th>Notional</th><th>Status</th><th>Submitted</th><th>Price relation</th><th>Ladder relation</th><th>Projected exposure</th><th>Reason</th></tr>
+          {_combined_order_rows(state, order_reviews)}
+        </table>
+      </div>
+    </section>
   </section>
 
-  <section class="card">
-    <h2>Positions</h2>
-    <div class="table-scroll">
-      <table>
-        <tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>Value</th><th>Allocation</th><th>Updated</th></tr>
-        {_position_rows(state)}
-      </table>
-    </div>
-  </section>
-
-  <section class="card">
-    <h2>Open orders</h2>
-    <div class="table-scroll">
-      <table>
-        <tr><th>Symbol</th><th>Side</th><th>Type</th><th>Quantity</th><th>Limit</th><th>Notional</th><th>Status</th><th>Submitted</th></tr>
-        {_order_rows(state)}
-      </table>
-    </div>
-  </section>
-
-  <section class="card">
-    <h2>Edit local CSVs</h2>
-    <div class="card warning">Local CSV update only. This does not place, cancel, or modify broker orders.</div>
-    {_forms()}
+  <section class="tab-panel" id="tab-edit">
+    <section class="card">
+      <h2>Edit local CSVs</h2>
+      <div class="card warning">Local CSV update only. This does not place, cancel, or modify broker orders.</div>
+      {_forms()}
+    </section>
   </section>
 </main>
 <script>
@@ -287,6 +301,15 @@ def render_status_page() -> str:
   updateLocalClock();
   setInterval(updateLocalClock, 1000);
   setTimeout(function () {{ window.location.reload(); }}, 60 * 60 * 1000);
+  document.querySelectorAll('.tab-button').forEach(function (button) {{
+    button.addEventListener('click', function () {{
+      document.querySelectorAll('.tab-button').forEach(function (node) {{ node.classList.remove('active'); }});
+      document.querySelectorAll('.tab-panel').forEach(function (node) {{ node.classList.remove('active'); }});
+      button.classList.add('active');
+      var panel = document.getElementById('tab-' + button.dataset.tab);
+      if (panel) {{ panel.classList.add('active'); }}
+    }});
+  }});
 </script>
 </body>
 </html>
@@ -490,6 +513,61 @@ def _order_rows(state) -> str:
             "</tr>"
         )
     return "\n".join(rows) or "<tr><td colspan='8'>No local open orders.</td></tr>"
+
+
+def _position_review_rows(state, reviews, traded_symbol: str) -> str:
+    review_map = {row.symbol: row for row in reviews}
+    updated = {position.symbol: position.updated_at for position in state.positions}
+    rows = []
+    for symbol in sorted(state.symbols):
+        item = state.symbols[symbol]
+        review = review_map.get(symbol)
+        if symbol == traded_symbol:
+            status = "TRADED_SYMBOL"
+            note = "Primary modeled symbol for daily decision."
+        elif review is None:
+            status = "REVIEW"
+            note = "No non-traded holding review available."
+        else:
+            status = review.status
+            note = f"Price {review.price_status}; no model-backed prediction."
+        rows.append(
+            "<tr>"
+            f"<td>{escape(symbol)}</td>"
+            f"<td>{item.quantity:g}</td>"
+            f"<td>{_money(item.latest_price)}</td>"
+            f"<td>{_money(item.market_value)}</td>"
+            f"<td>{_allocation(item.allocation_pct)}</td>"
+            f"<td>{escape(updated.get(symbol, ''))}</td>"
+            f"<td>{escape(status)}</td>"
+            f"<td>{escape(note)}</td>"
+            "</tr>"
+        )
+    return "\n".join(rows) or "<tr><td colspan='8'>No local positions or orders.</td></tr>"
+
+
+def _combined_order_rows(state, reviews) -> str:
+    rows = []
+    for order, review in zip(state.open_orders, reviews):
+        rows.append(
+            "<tr>"
+            f"<td class=\"action-{escape(review.recommended_action)}\">"
+            f"{escape(review.recommended_action)}</td>"
+            f"<td>{escape(order.symbol)}</td>"
+            f"<td>{escape(order.side)}</td>"
+            f"<td>{escape(order.type)}</td>"
+            f"<td>{order.quantity:g}</td>"
+            f"<td>{_money(order.limit_price)}</td>"
+            f"<td>{_money(order.exposure)}</td>"
+            f"<td>{escape(order.status)}</td>"
+            f"<td>{escape(order.submitted_at)}</td>"
+            f"<td>{escape(review.price_relation)}</td>"
+            f"<td>{escape(review.ladder_relation)}</td>"
+            f"<td>{_money(review.projected_exposure)}</td>"
+            f"<td>{escape(review.reason)}</td>"
+            "</tr>"
+        )
+    return "\n".join(rows) or "<tr><td colspan='13'>No local open orders.</td></tr>"
 
 
 def _holding_review_rows(rows) -> str:

--- a/src/trading_lab/portfolio/gui.py
+++ b/src/trading_lab/portfolio/gui.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from html import escape
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs
+import webbrowser
+
+from trading_lab.portfolio.state import (
+    ACCOUNT_PATH,
+    OPEN_ORDERS_PATH,
+    POSITIONS_PATH,
+    append_open_order,
+    build_portfolio_state,
+    clear_open_orders,
+    summarize_portfolio_state,
+    update_position_quantity,
+    write_account_value,
+    write_position,
+)
+
+
+def render_status_page() -> str:
+    state = build_portfolio_state()
+    position_rows = "\n".join(_position_row(item) for item in state.symbols.values())
+    if not position_rows:
+        position_rows = "<tr><td colspan='5'>No local positions or orders.</td></tr>"
+
+    order_rows = "\n".join(
+        "<tr>"
+        f"<td>{escape(order.symbol)}</td>"
+        f"<td>{escape(order.side)}</td>"
+        f"<td>{escape(order.type)}</td>"
+        f"<td>{order.quantity:g}</td>"
+        f"<td>{order.limit_price:.2f}</td>"
+        f"<td>{escape(order.status)}</td>"
+        "</tr>"
+        for order in state.open_orders
+    )
+    if not order_rows:
+        order_rows = "<tr><td colspan='6'>No local open orders.</td></tr>"
+
+    return f"""<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>trading-lab portfolio</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 24px; max-width: 1100px; }}
+    table {{ border-collapse: collapse; width: 100%; margin: 12px 0 24px; }}
+    th, td {{ border: 1px solid #ccc; padding: 6px 8px; text-align: left; }}
+    form {{ border: 1px solid #ccc; padding: 12px; margin: 12px 0; }}
+    input, select, button {{ margin: 4px; }}
+    pre {{ background: #f6f6f6; padding: 12px; overflow: auto; }}
+  </style>
+</head>
+<body>
+  <h1>Local portfolio</h1>
+  <p>Cash: {_money(state.cash)} | Account value: {_money(state.account_value)}</p>
+  <pre>{escape(summarize_portfolio_state(state))}</pre>
+
+  <h2>Positions</h2>
+  <table>
+    <tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>Value</th><th>Allocation</th></tr>
+    {position_rows}
+  </table>
+
+  <h2>Open orders</h2>
+  <table>
+    <tr><th>Symbol</th><th>Side</th><th>Type</th><th>Quantity</th><th>Limit</th><th>Status</th></tr>
+    {order_rows}
+  </table>
+
+  <h2>Edit local CSVs</h2>
+  <form method="post" action="/account">
+    <label>Cash <input name="cash" type="number" step="any"></label>
+    <label>Account value <input name="account_value" type="number" step="any"></label>
+    <button type="submit">Save account</button>
+  </form>
+  <form method="post" action="/position/set">
+    <label>Symbol <input name="symbol" required></label>
+    <label>Quantity <input name="quantity" type="number" step="any" required></label>
+    <button type="submit">Set position</button>
+  </form>
+  <form method="post" action="/position/update">
+    <select name="side"><option>buy</option><option>sell</option></select>
+    <label>Symbol <input name="symbol" required></label>
+    <label>Quantity <input name="quantity" type="number" step="any" required></label>
+    <label><input name="allow_negative" type="checkbox" value="1"> allow negative</label>
+    <button type="submit">Apply position update</button>
+  </form>
+  <form method="post" action="/order/add">
+    <select name="side"><option>buy</option><option>sell</option></select>
+    <label>Symbol <input name="symbol" required></label>
+    <label>Quantity <input name="quantity" type="number" step="any" required></label>
+    <label>Limit <input name="limit_price" type="number" step="any" required></label>
+    <button type="submit">Add limit order</button>
+  </form>
+  <form method="post" action="/order/clear">
+    <label>Symbol <input name="symbol"></label>
+    <button type="submit">Clear symbol orders</button>
+    <button type="submit" name="all" value="1">Clear all orders</button>
+  </form>
+</body>
+</html>
+"""
+
+
+def apply_form_action(path: str, fields: dict[str, str]) -> str:
+    if path == "/account":
+        if fields.get("cash", "").strip():
+            write_account_value(ACCOUNT_PATH, "cash", float(fields["cash"]))
+        if fields.get("account_value", "").strip():
+            write_account_value(ACCOUNT_PATH, "account_value", float(fields["account_value"]))
+        return "updated account.csv locally"
+    if path == "/position/set":
+        write_position(POSITIONS_PATH, fields["symbol"], float(fields["quantity"]))
+        return "set local position"
+    if path == "/position/update":
+        side = fields.get("side", "buy")
+        quantity = float(fields["quantity"])
+        delta = quantity if side == "buy" else -quantity
+        update_position_quantity(
+            POSITIONS_PATH,
+            fields["symbol"],
+            delta,
+            allow_negative=fields.get("allow_negative") == "1",
+        )
+        return "updated local position"
+    if path == "/order/add":
+        append_open_order(
+            OPEN_ORDERS_PATH,
+            side=fields.get("side", "buy"),
+            symbol=fields["symbol"],
+            quantity=float(fields["quantity"]),
+            limit_price=float(fields["limit_price"]),
+        )
+        return "added local order"
+    if path == "/order/clear":
+        symbol = fields.get("symbol", "").strip()
+        clear_open_orders(OPEN_ORDERS_PATH, None if fields.get("all") == "1" else symbol)
+        return "cleared local orders"
+    raise ValueError(f"Unknown form action: {path}")
+
+
+def _position_row(item) -> str:
+    allocation = f"{item.allocation_pct:.1%}" if item.allocation_pct is not None else "unknown"
+    return (
+        "<tr>"
+        f"<td>{escape(item.symbol)}</td>"
+        f"<td>{item.quantity:g}</td>"
+        f"<td>{_money(item.latest_price)}</td>"
+        f"<td>{_money(item.market_value)}</td>"
+        f"<td>{allocation}</td>"
+        "</tr>"
+    )
+
+
+def run_gui(host: str = "127.0.0.1", port: int = 8765) -> None:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            body = render_status_page().encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length).decode("utf-8")
+            fields = {key: values[-1] for key, values in parse_qs(raw).items()}
+            try:
+                apply_form_action(self.path, fields)
+                self.send_response(303)
+                self.send_header("Location", "/")
+                self.end_headers()
+            except Exception as exc:
+                body = escape(str(exc)).encode("utf-8")
+                self.send_response(400)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        def log_message(self, format: str, *args) -> None:
+            return
+
+    server = ThreadingHTTPServer((host, port), Handler)
+    url = f"http://{host}:{server.server_port}/"
+    print(f"Local-only portfolio GUI: {url}")
+    print("Press Ctrl+C to stop.")
+    webbrowser.open(url)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopping portfolio GUI.")
+    finally:
+        server.server_close()
+
+
+def _money(value: float | None) -> str:
+    if value is None:
+        return "unavailable"
+    return f"${value:,.2f}"

--- a/src/trading_lab/portfolio/review.py
+++ b/src/trading_lab/portfolio/review.py
@@ -39,6 +39,14 @@ class OrderReviewSummary:
     top_actions: tuple[OrderReview, ...]
 
 
+@dataclass(frozen=True)
+class ExposureContext:
+    traded_symbol: str
+    current_exposure: float | None
+    max_exposure: float | None
+    buy_capacity: float | None
+
+
 def review_holdings(
     state: PortfolioState,
     traded_symbol: str,
@@ -122,10 +130,14 @@ def review_open_orders(
         ladder_relation = _ladder_relation(order, first_ladder)
         if remaining_buy_capacity is not None and remaining_buy_capacity <= 0:
             action = "CANCEL"
-            reason = "Buy capacity is $0 under the max recommended exposure."
+            reason = _zero_capacity_buy_reason(order, traded, current_value, max_exposure)
         elif remaining_buy_capacity is not None and order.exposure > remaining_buy_capacity:
             action = "REDUCE"
-            reason = "Order notional exceeds remaining buy capacity."
+            reason = (
+                f"Reduce this buy: order notional {_money(order.exposure)} exceeds remaining "
+                f"buy capacity {_money(remaining_buy_capacity)}; projected exposure would be "
+                f"{_money(current_value + order.exposure)}."
+            )
             remaining_buy_capacity = 0.0
         elif first_ladder is not None and order.limit_price > first_ladder * 1.01:
             action = "MOVE_LOWER"
@@ -160,6 +172,112 @@ def summarize_order_reviews(reviews: tuple[OrderReview, ...]) -> OrderReviewSumm
     )
 
 
+def exposure_context(
+    state: PortfolioState,
+    traded_symbol: str,
+    account_value: float,
+    max_allocation: float | None,
+) -> ExposureContext:
+    traded = traded_symbol.upper()
+    item = state.symbols.get(traded)
+    current = item.market_value if item is not None else None
+    max_exposure = account_value * max_allocation if max_allocation is not None else None
+    capacity = (
+        max(max_exposure - (current or 0.0), 0.0)
+        if max_exposure is not None and current is not None
+        else None
+    )
+    return ExposureContext(traded, current, max_exposure, capacity)
+
+
+def advice_lines(
+    state: PortfolioState,
+    traded_symbol: str,
+    *,
+    action: str,
+    max_exposure: float | None,
+    order_summary: OrderReviewSummary,
+) -> tuple[str, ...]:
+    traded = traded_symbol.upper()
+    item = state.symbols.get(traded)
+    current = item.market_value if item is not None else None
+    lines = [f"Hold current {traded}." if action == "HOLD" else f"Current action is {action}."]
+    lines.append(f"Do not add new {traded} buys now.")
+    if current is not None and max_exposure is not None and current > max_exposure:
+        lines.append(
+            f"Current {traded} exposure ({_money(current)}) is already slightly above "
+            f"the model max ({_money(max_exposure)})."
+        )
+    if order_summary.total_pending_buy_notional > 0:
+        lines.append(
+            f"Pending buy orders ({_money(order_summary.total_pending_buy_notional)}) "
+            "are much too large relative to the current model recommendation."
+        )
+    sell_orders = [
+        order
+        for order in state.open_orders
+        if order.symbol == traded and order.side == "sell" and order.status == "placed"
+    ]
+    if sell_orders:
+        first = sell_orders[0]
+        lines.append(
+            f"Sell order at {first.limit_price:g} reduces exposure and can be kept/reviewed."
+        )
+    lines.append(
+        "Non-traded holdings are tiny portfolio dust/status, not model-backed trade signals."
+    )
+    return tuple(lines)
+
+
+def suggested_order_ideas(
+    state: PortfolioState,
+    traded_symbol: str,
+    *,
+    context: ExposureContext,
+    reviews: tuple[OrderReview, ...],
+    ladder: tuple[str, ...] = (),
+) -> tuple[str, ...]:
+    traded = traded_symbol.upper()
+    ideas: list[str] = []
+    if context.buy_capacity is not None and context.buy_capacity <= 0:
+        ideas.append("No new buy orders. Cancel/reduce existing buys first.")
+    elif context.buy_capacity is not None:
+        first_ladder = _first_ladder_price(ladder)
+        if first_ladder is not None and first_ladder > 0:
+            size = int(context.buy_capacity // first_ladder)
+            if size <= 0:
+                ideas.append("No new buy orders. Cancel/reduce existing buys first.")
+            else:
+                ideas.append(
+                    f"Possible {traded} buy idea: up to {size:g} share(s) near "
+                    f"{_money(first_ladder)} from the ladder."
+                )
+        else:
+            ideas.append(f"Possible {traded} buy idea: keep notional under {_money(context.buy_capacity)}.")
+    else:
+        ideas.append("No new buy idea because buy capacity is unknown.")
+    if any(row.side == "buy" and row.recommended_action in {"CANCEL", "REDUCE"} for row in reviews):
+        ideas.append(f"Cancel/reduce current pending {traded} buys.")
+    for row in reviews:
+        if row.symbol == traded and row.side == "sell" and row.recommended_action in {"KEEP", "REVIEW"}:
+            ideas.append(
+                f"Keep/review the {traded} sell {row.quantity:g} @ {_money(row.limit_price)} "
+                "because it reduces exposure."
+            )
+            break
+    if (
+        context.current_exposure is not None
+        and context.max_exposure is not None
+        and context.current_exposure > context.max_exposure
+    ):
+        excess = context.current_exposure - context.max_exposure
+        ideas.append(
+            f"Over max by about {_money(excess)}; too small to justify a market sell by itself, "
+            "so focus on canceling pending buys."
+        )
+    return tuple(ideas)
+
+
 def _review_other_symbol_order(
     order: OpenOrder,
     state: PortfolioState,
@@ -184,6 +302,25 @@ def _review_traded_sell(
     if max_exposure is not None and current_value > max_exposure:
         return _order_review(order, state, "KEEP", "Sell order reduces overexposure.")
     return _order_review(order, state, "REVIEW", "Sell order reduces exposure; review manually.")
+
+
+def _zero_capacity_buy_reason(
+    order: OpenOrder,
+    traded: str,
+    current_value: float,
+    max_exposure: float | None,
+) -> str:
+    projected = current_value + order.exposure
+    if max_exposure is None:
+        return (
+            f"Cancel this buy: buy capacity is $0, order notional is {_money(order.exposure)}, "
+            f"and projected exposure after fill would be {_money(projected)}."
+        )
+    return (
+        f"Cancel this buy: current {traded} exposure is already {_money(current_value)} "
+        f"vs max {_money(max_exposure)}, order notional is {_money(order.exposure)}, "
+        f"and filling this order would raise exposure to {_money(projected)}."
+    )
 
 
 def _order_review(
@@ -242,3 +379,9 @@ def _first_ladder_price(ladder: tuple[str, ...]) -> float | None:
         if match:
             return float(match.group(1).replace(",", ""))
     return None
+
+
+def _money(value: float | None) -> str:
+    if value is None:
+        return "unavailable"
+    return f"${value:,.2f}"

--- a/src/trading_lab/portfolio/review.py
+++ b/src/trading_lab/portfolio/review.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from trading_lab.portfolio.state import OpenOrder, PortfolioState, SymbolPortfolioState
+
+
+@dataclass(frozen=True)
+class HoldingReview:
+    symbol: str
+    quantity: float
+    value: float | None
+    allocation: float | None
+    price_status: str
+    status: str
+
+
+@dataclass(frozen=True)
+class OrderReview:
+    symbol: str
+    side: str
+    quantity: float
+    limit_price: float
+    notional: float
+    status: str
+    price_relation: str
+    ladder_relation: str
+    projected_exposure: float | None
+    recommended_action: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class OrderReviewSummary:
+    total_pending_buy_notional: float
+    total_pending_sell_notional: float
+    cancel_reduce_review_count: int
+    top_actions: tuple[OrderReview, ...]
+
+
+def review_holdings(
+    state: PortfolioState,
+    traded_symbol: str,
+    small_threshold: float = 0.02,
+    review_size_threshold: float = 0.05,
+) -> tuple[HoldingReview, ...]:
+    rows: list[HoldingReview] = []
+    traded = traded_symbol.upper()
+    for symbol in sorted(state.symbols):
+        if symbol == traded:
+            continue
+        item = state.symbols[symbol]
+        if item.quantity == 0:
+            continue
+        if item.latest_price is None:
+            status = "PRICE_MISSING"
+            price_status = "missing"
+        elif item.allocation_pct is None:
+            status = "REVIEW"
+            price_status = "known"
+        elif item.allocation_pct < small_threshold:
+            status = "OK_SMALL"
+            price_status = "known"
+        elif item.allocation_pct <= review_size_threshold:
+            status = "REVIEW"
+            price_status = "known"
+        else:
+            status = "REVIEW_SIZE"
+            price_status = "known"
+        rows.append(
+            HoldingReview(
+                symbol=symbol,
+                quantity=item.quantity,
+                value=item.market_value,
+                allocation=item.allocation_pct,
+                price_status=price_status,
+                status=status,
+            )
+        )
+    return tuple(rows)
+
+
+def review_open_orders(
+    state: PortfolioState,
+    traded_symbol: str,
+    *,
+    account_value: float,
+    max_allocation: float | None,
+    suggested_action: str,
+    strategy_eligible: bool,
+    ladder: tuple[str, ...] = (),
+) -> tuple[OrderReview, ...]:
+    traded = traded_symbol.upper()
+    first_ladder = _first_ladder_price(ladder)
+    current = state.symbols.get(traded)
+    current_value = (current.market_value or 0.0) if current is not None else 0.0
+    max_exposure = account_value * max_allocation if max_allocation is not None else None
+    remaining_buy_capacity = (
+        max(max_exposure - current_value, 0.0) if max_exposure is not None else None
+    )
+
+    reviews: list[OrderReview] = []
+    for order in state.open_orders:
+        if order.status.lower() != "placed":
+            reviews.append(_order_review(order, state, "REVIEW", "Order is not placed."))
+            continue
+        if order.symbol != traded:
+            reviews.append(_review_other_symbol_order(order, state, account_value))
+            continue
+        if order.side == "sell":
+            reviews.append(_review_traded_sell(order, state, max_exposure, current_value))
+            continue
+        if order.side != "buy":
+            reviews.append(_order_review(order, state, "REVIEW", "Unsupported order side."))
+            continue
+
+        aggressive = (
+            suggested_action in {"WAIT_FOR_PULLBACK", "SPY_CORE_ONLY_OR_WAIT"}
+            and not strategy_eligible
+        )
+        ladder_relation = _ladder_relation(order, first_ladder)
+        if remaining_buy_capacity is not None and remaining_buy_capacity <= 0:
+            action = "CANCEL"
+            reason = "Buy capacity is $0 under the max recommended exposure."
+        elif remaining_buy_capacity is not None and order.exposure > remaining_buy_capacity:
+            action = "REDUCE"
+            reason = "Order notional exceeds remaining buy capacity."
+            remaining_buy_capacity = 0.0
+        elif first_ladder is not None and order.limit_price > first_ladder * 1.01:
+            action = "MOVE_LOWER"
+            reason = "Buy limit is above the first suggested ladder price."
+            if remaining_buy_capacity is not None:
+                remaining_buy_capacity -= order.exposure
+        elif aggressive:
+            action = "REVIEW"
+            reason = "Strategy is not eligible; review pending buy before adding risk."
+            if remaining_buy_capacity is not None:
+                remaining_buy_capacity -= order.exposure
+        else:
+            action = "KEEP"
+            reason = "Order fits remaining buy capacity and ladder context."
+            if remaining_buy_capacity is not None:
+                remaining_buy_capacity -= order.exposure
+        reviews.append(_order_review(order, state, action, reason, ladder_relation=ladder_relation))
+    return tuple(reviews)
+
+
+def summarize_order_reviews(reviews: tuple[OrderReview, ...]) -> OrderReviewSummary:
+    buy_notional = sum(row.notional for row in reviews if row.side == "buy" and row.status == "placed")
+    sell_notional = sum(row.notional for row in reviews if row.side == "sell" and row.status == "placed")
+    flagged = [row for row in reviews if row.recommended_action in {"CANCEL", "REDUCE", "REVIEW"}]
+    priority = {"CANCEL": 0, "REDUCE": 1, "MOVE_LOWER": 2, "REVIEW": 3, "KEEP": 4}
+    top_actions = tuple(sorted(flagged, key=lambda row: priority[row.recommended_action])[:3])
+    return OrderReviewSummary(
+        total_pending_buy_notional=buy_notional,
+        total_pending_sell_notional=sell_notional,
+        cancel_reduce_review_count=len(flagged),
+        top_actions=top_actions,
+    )
+
+
+def _review_other_symbol_order(
+    order: OpenOrder,
+    state: PortfolioState,
+    account_value: float,
+) -> OrderReview:
+    allocation = order.exposure / account_value if account_value > 0 else 0.0
+    if allocation > 0.05:
+        action = "REVIEW"
+        reason = "No model signal for this symbol and order exceeds 5% sizing check."
+    else:
+        action = "REVIEW"
+        reason = "No configured model signal for this symbol; review manually."
+    return _order_review(order, state, action, reason)
+
+
+def _review_traded_sell(
+    order: OpenOrder,
+    state: PortfolioState,
+    max_exposure: float | None,
+    current_value: float,
+) -> OrderReview:
+    if max_exposure is not None and current_value > max_exposure:
+        return _order_review(order, state, "KEEP", "Sell order reduces overexposure.")
+    return _order_review(order, state, "REVIEW", "Sell order reduces exposure; review manually.")
+
+
+def _order_review(
+    order: OpenOrder,
+    state: PortfolioState,
+    action: str,
+    reason: str,
+    *,
+    ladder_relation: str = "not applicable",
+) -> OrderReview:
+    item = state.symbols.get(order.symbol)
+    projected = _projected_exposure(order, item)
+    return OrderReview(
+        symbol=order.symbol,
+        side=order.side,
+        quantity=order.quantity,
+        limit_price=order.limit_price,
+        notional=order.exposure,
+        status=order.status,
+        price_relation=_price_relation(order, item),
+        ladder_relation=ladder_relation,
+        projected_exposure=projected,
+        recommended_action=action,
+        reason=reason,
+    )
+
+
+def _projected_exposure(order: OpenOrder, item: SymbolPortfolioState | None) -> float | None:
+    current_value = item.market_value if item is not None else None
+    if current_value is None:
+        return None
+    if order.side == "buy":
+        return current_value + order.exposure
+    if order.side == "sell":
+        return max(current_value - order.exposure, 0.0)
+    return current_value
+
+
+def _price_relation(order: OpenOrder, item: SymbolPortfolioState | None) -> str:
+    if item is None or item.latest_price is None:
+        return "price missing"
+    diff = (order.limit_price / item.latest_price) - 1.0
+    return f"{diff:+.1%} vs current"
+
+
+def _ladder_relation(order: OpenOrder, first_ladder: float | None) -> str:
+    if first_ladder is None:
+        return "no ladder"
+    diff = (order.limit_price / first_ladder) - 1.0
+    return f"{diff:+.1%} vs first ladder"
+
+
+def _first_ladder_price(ladder: tuple[str, ...]) -> float | None:
+    for line in ladder:
+        match = re.search(r"limit\s+\$?([0-9][0-9,.]*)", line, flags=re.IGNORECASE)
+        if match:
+            return float(match.group(1).replace(",", ""))
+    return None

--- a/src/trading_lab/portfolio/review.py
+++ b/src/trading_lab/portfolio/review.py
@@ -98,7 +98,9 @@ def review_open_orders(
     suggested_action: str,
     strategy_eligible: bool,
     ladder: tuple[str, ...] = (),
+    risk_mode: str = "conservative",
 ) -> tuple[OrderReview, ...]:
+    mode = normalize_risk_mode(risk_mode)
     traded = traded_symbol.upper()
     first_ladder = _first_ladder_price(ladder)
     current = state.symbols.get(traded)
@@ -128,7 +130,30 @@ def review_open_orders(
             and not strategy_eligible
         )
         ladder_relation = _ladder_relation(order, first_ladder)
-        if remaining_buy_capacity is not None and remaining_buy_capacity <= 0:
+        if mode == "aggressive":
+            action, reason = _aggressive_buy_action(
+                order,
+                traded,
+                current_value,
+                max_exposure,
+                first_ladder,
+                aggressive,
+            )
+        elif mode == "balanced":
+            action, reason = _balanced_buy_action(
+                order,
+                traded,
+                current_value,
+                max_exposure,
+                remaining_buy_capacity,
+                first_ladder,
+                aggressive,
+            )
+            if remaining_buy_capacity is not None and action in {"KEEP", "REVIEW"}:
+                remaining_buy_capacity -= order.exposure
+            elif remaining_buy_capacity is not None and action == "REDUCE":
+                remaining_buy_capacity = 0.0
+        elif remaining_buy_capacity is not None and remaining_buy_capacity <= 0:
             action = "CANCEL"
             reason = _zero_capacity_buy_reason(order, traded, current_value, max_exposure)
         elif remaining_buy_capacity is not None and order.exposure > remaining_buy_capacity:
@@ -197,12 +222,25 @@ def advice_lines(
     action: str,
     max_exposure: float | None,
     order_summary: OrderReviewSummary,
+    risk_mode: str = "conservative",
 ) -> tuple[str, ...]:
+    mode = normalize_risk_mode(risk_mode)
     traded = traded_symbol.upper()
     item = state.symbols.get(traded)
     current = item.market_value if item is not None else None
-    lines = [f"Hold current {traded}." if action == "HOLD" else f"Current action is {action}."]
-    lines.append(f"Do not add new {traded} buys now.")
+    lines = [f"Risk mode: {mode}."]
+    if mode == "aggressive":
+        lines.append("Aggressive mode accepts higher drawdown risk.")
+        lines.append("Trend-first advice: prefer deeper, ladder-aligned buys over exposure-only rules.")
+    elif mode == "balanced":
+        lines.append("Balanced mode blends exposure limits with trend and ladder quality.")
+    else:
+        lines.append("Conservative mode is exposure-first.")
+    lines.append(f"Hold current {traded}." if action == "HOLD" else f"Current action is {action}.")
+    if mode == "aggressive":
+        lines.append(f"Do not add shallow {traded} buys now; only deep ladder-aligned orders merit review.")
+    else:
+        lines.append(f"Do not add new {traded} buys now.")
     if current is not None and max_exposure is not None and current > max_exposure:
         lines.append(
             f"Current {traded} exposure ({_money(current)}) is already slightly above "
@@ -236,11 +274,15 @@ def suggested_order_ideas(
     context: ExposureContext,
     reviews: tuple[OrderReview, ...],
     ladder: tuple[str, ...] = (),
+    risk_mode: str = "conservative",
 ) -> tuple[str, ...]:
+    mode = normalize_risk_mode(risk_mode)
     traded = traded_symbol.upper()
     ideas: list[str] = []
-    if context.buy_capacity is not None and context.buy_capacity <= 0:
+    if context.buy_capacity is not None and context.buy_capacity <= 0 and mode != "aggressive":
         ideas.append("No new buy orders. Cancel/reduce existing buys first.")
+    elif context.buy_capacity is not None and context.buy_capacity <= 0:
+        ideas.append("No new shallow buy orders; aggressive mode may review only deep ladder-aligned buys.")
     elif context.buy_capacity is not None:
         first_ladder = _first_ladder_price(ladder)
         if first_ladder is not None and first_ladder > 0:
@@ -276,6 +318,13 @@ def suggested_order_ideas(
             "so focus on canceling pending buys."
         )
     return tuple(ideas)
+
+
+def normalize_risk_mode(value: str | None) -> str:
+    mode = (value or "conservative").strip().lower()
+    if mode not in {"conservative", "balanced", "aggressive"}:
+        raise ValueError("risk mode must be conservative, balanced, or aggressive")
+    return mode
 
 
 def _review_other_symbol_order(
@@ -320,6 +369,68 @@ def _zero_capacity_buy_reason(
         f"Cancel this buy: current {traded} exposure is already {_money(current_value)} "
         f"vs max {_money(max_exposure)}, order notional is {_money(order.exposure)}, "
         f"and filling this order would raise exposure to {_money(projected)}."
+    )
+
+
+def _balanced_buy_action(
+    order: OpenOrder,
+    traded: str,
+    current_value: float,
+    max_exposure: float | None,
+    remaining_buy_capacity: float | None,
+    first_ladder: float | None,
+    weak_setup: bool,
+) -> tuple[str, str]:
+    if first_ladder is not None and order.limit_price <= first_ladder * 0.97:
+        return (
+            "REVIEW",
+            f"Balanced mode: deep {traded} buy is below/near the deeper ladder area; "
+            f"exposure warning remains because filling it projects exposure to "
+            f"{_money(current_value + order.exposure)}.",
+        )
+    if remaining_buy_capacity is not None and remaining_buy_capacity <= 0:
+        return "CANCEL", _zero_capacity_buy_reason(order, traded, current_value, max_exposure)
+    if weak_setup and first_ladder is not None and order.limit_price > first_ladder:
+        return (
+            "REDUCE",
+            "Balanced mode: model setup is weak, so shallow/high pending buys should be reduced.",
+        )
+    if remaining_buy_capacity is not None and order.exposure > remaining_buy_capacity:
+        return (
+            "REDUCE",
+            f"Balanced mode: order notional {_money(order.exposure)} exceeds remaining "
+            f"buy capacity {_money(remaining_buy_capacity)}.",
+        )
+    return "KEEP", "Balanced mode: order fits capacity or ladder context."
+
+
+def _aggressive_buy_action(
+    order: OpenOrder,
+    traded: str,
+    current_value: float,
+    max_exposure: float | None,
+    first_ladder: float | None,
+    weak_setup: bool,
+) -> tuple[str, str]:
+    projected = current_value + order.exposure
+    if first_ladder is not None and order.limit_price <= first_ladder * 0.97:
+        return (
+            "REVIEW",
+            f"Aggressive mode accepts higher drawdown risk; this deeper {traded} buy is "
+            f"below the first ladder area. Exposure warning: current {_money(current_value)} "
+            f"vs max {_money(max_exposure)}, projected {_money(projected)}.",
+        )
+    if first_ladder is not None and order.limit_price <= first_ladder:
+        return (
+            "REVIEW",
+            f"Aggressive mode: near-ladder {traded} buy can be reviewed, but exposure warning "
+            f"remains because projected exposure is {_money(projected)} vs max {_money(max_exposure)}.",
+        )
+    action = "REDUCE" if weak_setup else "MOVE_LOWER"
+    return (
+        action,
+        f"Aggressive mode still avoids shallow/high buys when setup is weak; move lower toward "
+        f"the ladder. Projected exposure would be {_money(projected)}.",
     )
 
 

--- a/src/trading_lab/portfolio/state.py
+++ b/src/trading_lab/portfolio/state.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+
+POSITIONS_PATH = Path("data/raw/portfolio/positions.csv")
+OPEN_ORDERS_PATH = Path("data/raw/portfolio/open_orders.csv")
+MARKET_DIR = Path("data/raw/market")
+
+POSITION_COLUMNS = ("symbol", "quantity", "notes", "updated_at")
+OPEN_ORDER_COLUMNS = (
+    "symbol",
+    "side",
+    "type",
+    "quantity",
+    "limit_price",
+    "time_in_force",
+    "status",
+    "submitted_at",
+    "notes",
+)
+
+
+@dataclass(frozen=True)
+class Position:
+    symbol: str
+    quantity: float
+    notes: str = ""
+    updated_at: str = ""
+
+
+@dataclass(frozen=True)
+class OpenOrder:
+    symbol: str
+    side: str
+    type: str
+    quantity: float
+    limit_price: float
+    time_in_force: str = ""
+    status: str = ""
+    submitted_at: str = ""
+    notes: str = ""
+
+    @property
+    def exposure(self) -> float:
+        return self.quantity * self.limit_price
+
+    @property
+    def is_placed_limit(self) -> bool:
+        return self.status.lower() == "placed" and self.type.lower() == "limit"
+
+
+@dataclass(frozen=True)
+class SymbolPortfolioState:
+    symbol: str
+    quantity: float = 0.0
+    latest_price: float | None = None
+    market_value: float | None = None
+    allocation_pct: float | None = None
+    pending_buy_quantity: float = 0.0
+    pending_buy_value: float = 0.0
+    pending_sell_quantity: float = 0.0
+    pending_sell_value: float = 0.0
+    post_fill_quantity: float = 0.0
+    post_fill_value: float | None = None
+
+
+@dataclass(frozen=True)
+class PortfolioState:
+    positions: tuple[Position, ...] = ()
+    open_orders: tuple[OpenOrder, ...] = ()
+    symbols: dict[str, SymbolPortfolioState] = field(default_factory=dict)
+    prices: dict[str, float] = field(default_factory=dict)
+    account_value: float | None = None
+    cash: float | None = None
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def total_market_value(self) -> float:
+        return sum(symbol.market_value or 0.0 for symbol in self.symbols.values())
+
+
+def read_positions(path: Path = POSITIONS_PATH) -> tuple[Position, ...]:
+    if not path.exists():
+        return ()
+    rows = _read_csv_rows(path, set(POSITION_COLUMNS[:2]))
+    positions: list[Position] = []
+    for row in rows:
+        symbol = row["symbol"].strip().upper()
+        if not symbol:
+            continue
+        positions.append(
+            Position(
+                symbol=symbol,
+                quantity=_parse_float(row["quantity"], f"{path}: quantity for {symbol}"),
+                notes=row.get("notes", "").strip(),
+                updated_at=row.get("updated_at", "").strip(),
+            )
+        )
+    return tuple(positions)
+
+
+def read_open_orders(path: Path = OPEN_ORDERS_PATH) -> tuple[OpenOrder, ...]:
+    if not path.exists():
+        return ()
+    rows = _read_csv_rows(path, {"symbol", "side", "type", "quantity", "limit_price"})
+    orders: list[OpenOrder] = []
+    for row in rows:
+        symbol = row["symbol"].strip().upper()
+        side = row["side"].strip().lower()
+        order_type = row["type"].strip().lower()
+        if not symbol:
+            continue
+        orders.append(
+            OpenOrder(
+                symbol=symbol,
+                side=side,
+                type=order_type,
+                quantity=_parse_float(row["quantity"], f"{path}: quantity for {symbol}"),
+                limit_price=_parse_float(row["limit_price"], f"{path}: limit_price for {symbol}"),
+                time_in_force=row.get("time_in_force", "").strip(),
+                status=row.get("status", "").strip().lower(),
+                submitted_at=row.get("submitted_at", "").strip(),
+                notes=row.get("notes", "").strip(),
+            )
+        )
+    return tuple(orders)
+
+
+def latest_market_prices(market_dir: Path = MARKET_DIR) -> dict[str, float]:
+    if not market_dir.exists():
+        return {}
+    prices: dict[str, float] = {}
+    for path in sorted(market_dir.glob("*.csv")):
+        price = _latest_price_from_csv(path)
+        if price is not None:
+            prices[path.stem.upper()] = price
+    return prices
+
+
+def build_portfolio_state(
+    *,
+    positions_path: Path = POSITIONS_PATH,
+    open_orders_path: Path = OPEN_ORDERS_PATH,
+    market_dir: Path = MARKET_DIR,
+    account_value: float | None = None,
+    cash: float | None = None,
+) -> PortfolioState:
+    positions = read_positions(positions_path)
+    open_orders = read_open_orders(open_orders_path)
+    prices = latest_market_prices(market_dir)
+    warnings: list[str] = []
+
+    symbols = {position.symbol for position in positions} | {order.symbol for order in open_orders}
+    symbol_states: dict[str, SymbolPortfolioState] = {}
+
+    for symbol in sorted(symbols):
+        quantity = sum(position.quantity for position in positions if position.symbol == symbol)
+        price = prices.get(symbol)
+        market_value = quantity * price if price is not None else None
+        if price is None and quantity:
+            warnings.append(f"No latest market price found for {symbol}; market value unavailable.")
+
+        buys = [
+            order
+            for order in open_orders
+            if order.symbol == symbol and order.side == "buy" and order.is_placed_limit
+        ]
+        sells = [
+            order
+            for order in open_orders
+            if order.symbol == symbol and order.side == "sell" and order.is_placed_limit
+        ]
+        pending_buy_quantity = sum(order.quantity for order in buys)
+        pending_buy_value = sum(order.exposure for order in buys)
+        pending_sell_quantity = sum(order.quantity for order in sells)
+        pending_sell_value = sum(order.exposure for order in sells)
+        post_fill_quantity = quantity + pending_buy_quantity - pending_sell_quantity
+        post_fill_value = post_fill_quantity * price if price is not None else None
+        allocation_pct = (
+            market_value / account_value
+            if market_value is not None and account_value is not None and account_value > 0
+            else None
+        )
+
+        symbol_states[symbol] = SymbolPortfolioState(
+            symbol=symbol,
+            quantity=quantity,
+            latest_price=price,
+            market_value=market_value,
+            allocation_pct=allocation_pct,
+            pending_buy_quantity=pending_buy_quantity,
+            pending_buy_value=pending_buy_value,
+            pending_sell_quantity=pending_sell_quantity,
+            pending_sell_value=pending_sell_value,
+            post_fill_quantity=post_fill_quantity,
+            post_fill_value=post_fill_value,
+        )
+
+    return PortfolioState(
+        positions=positions,
+        open_orders=open_orders,
+        symbols=symbol_states,
+        prices=prices,
+        account_value=account_value,
+        cash=cash,
+        warnings=tuple(warnings),
+    )
+
+
+def summarize_portfolio_state(state: PortfolioState) -> str:
+    lines = ["== Portfolio state =="]
+    lines.append(f"Positions: {len(state.positions)}")
+    lines.append(f"Open orders: {len(state.open_orders)}")
+    if state.account_value is not None:
+        lines.append(f"Account value: ${state.account_value:,.2f}")
+    if state.cash is not None:
+        lines.append(f"Cash: ${state.cash:,.2f}")
+    if not state.symbols:
+        lines.append("No local positions or open orders found.")
+    else:
+        lines.append("")
+        lines.append("Symbol state:")
+        for symbol in sorted(state.symbols):
+            item = state.symbols[symbol]
+            price = _money(item.latest_price) if item.latest_price is not None else "unavailable"
+            value = _money(item.market_value) if item.market_value is not None else "unavailable"
+            allocation = (
+                f"{item.allocation_pct:.1%}" if item.allocation_pct is not None else "unknown"
+            )
+            post_value = (
+                _money(item.post_fill_value) if item.post_fill_value is not None else "unavailable"
+            )
+            lines.append(
+                f"- {symbol}: qty {item.quantity:g}, price {price}, value {value}, "
+                f"allocation {allocation}, pending buys {item.pending_buy_quantity:g} "
+                f"({_money(item.pending_buy_value)}), pending sells {item.pending_sell_quantity:g} "
+                f"({_money(item.pending_sell_value)}), post-fill qty {item.post_fill_quantity:g}, "
+                f"post-fill value {post_value}"
+            )
+    if state.warnings:
+        lines.append("")
+        lines.append("Warnings:")
+        lines.extend(f"- {warning}" for warning in state.warnings)
+    return "\n".join(lines)
+
+
+def portfolio_files_exist(
+    positions_path: Path = POSITIONS_PATH,
+    open_orders_path: Path = OPEN_ORDERS_PATH,
+) -> bool:
+    return positions_path.exists() or open_orders_path.exists()
+
+
+def write_position(path: Path, symbol: str, quantity: float) -> None:
+    symbol = symbol.strip().upper()
+    rows = [dict(row) for row in _read_csv_rows(path, set(), allow_missing=True)]
+    found = False
+    today = date.today().isoformat()
+    for row in rows:
+        if row.get("symbol", "").strip().upper() == symbol:
+            row.update(
+                {
+                    "symbol": symbol,
+                    "quantity": str(quantity),
+                    "notes": row.get("notes", "current_position") or "current_position",
+                    "updated_at": today,
+                }
+            )
+            found = True
+    if not found:
+        rows.append(
+            {
+                "symbol": symbol,
+                "quantity": str(quantity),
+                "notes": "current_position",
+                "updated_at": today,
+            }
+        )
+    _write_csv(path, POSITION_COLUMNS, rows)
+
+
+def append_open_order(
+    path: Path,
+    *,
+    side: str,
+    symbol: str,
+    quantity: float,
+    limit_price: float,
+    time_in_force: str = "GTC",
+    status: str = "placed",
+    notes: str = "current_open_order",
+) -> None:
+    rows = [dict(row) for row in _read_csv_rows(path, set(), allow_missing=True)]
+    rows.append(
+        {
+            "symbol": symbol.strip().upper(),
+            "side": side.strip().lower(),
+            "type": "limit",
+            "quantity": str(quantity),
+            "limit_price": f"{limit_price:.2f}",
+            "time_in_force": time_in_force,
+            "status": status,
+            "submitted_at": date.today().isoformat(),
+            "notes": notes,
+        }
+    )
+    _write_csv(path, OPEN_ORDER_COLUMNS, rows)
+
+
+def _read_csv_rows(
+    path: Path,
+    required: set[str],
+    allow_missing: bool = False,
+) -> list[dict[str, str]]:
+    if not path.exists():
+        return [] if allow_missing else []
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        columns = set(reader.fieldnames or ())
+        missing = required - columns
+        if missing:
+            raise ValueError(f"Missing required columns in {path}: {sorted(missing)}")
+        return [
+            {key: (value or "") for key, value in row.items() if key is not None}
+            for row in reader
+        ]
+
+
+def _write_csv(path: Path, columns: tuple[str, ...], rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(columns), extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _latest_price_from_csv(path: Path) -> float | None:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    if not rows:
+        return None
+
+    def price_column(row: dict[str, str]) -> str | None:
+        normalized = {_normalize_column(key): key for key in row}
+        for candidate in ("adj_close", "adjusted_close", "close"):
+            if candidate in normalized:
+                return normalized[candidate]
+        return None
+
+    for row in reversed(rows):
+        column = price_column(row)
+        if column is None:
+            return None
+        value = row.get(column, "")
+        if value.strip():
+            return _parse_float(value, f"{path}: latest close")
+    return None
+
+
+def _normalize_column(value: str) -> str:
+    return value.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _parse_float(value: str, context: str) -> float:
+    try:
+        return float(str(value).replace("$", "").replace(",", "").strip())
+    except ValueError as exc:
+        raise ValueError(f"Invalid numeric value for {context}: {value!r}") from exc
+
+
+def _money(value: float | None) -> str:
+    if value is None:
+        return "unavailable"
+    return f"${value:,.2f}"

--- a/src/trading_lab/portfolio/state.py
+++ b/src/trading_lab/portfolio/state.py
@@ -8,9 +8,11 @@ from pathlib import Path
 
 POSITIONS_PATH = Path("data/raw/portfolio/positions.csv")
 OPEN_ORDERS_PATH = Path("data/raw/portfolio/open_orders.csv")
+ACCOUNT_PATH = Path("data/raw/portfolio/account.csv")
 MARKET_DIR = Path("data/raw/market")
 
 POSITION_COLUMNS = ("symbol", "quantity", "notes", "updated_at")
+ACCOUNT_COLUMNS = ("key", "value", "updated_at")
 OPEN_ORDER_COLUMNS = (
     "symbol",
     "side",
@@ -83,6 +85,12 @@ class PortfolioState:
         return sum(symbol.market_value or 0.0 for symbol in self.symbols.values())
 
 
+@dataclass(frozen=True)
+class AccountState:
+    cash: float | None = None
+    account_value: float | None = None
+
+
 def read_positions(path: Path = POSITIONS_PATH) -> tuple[Position, ...]:
     if not path.exists():
         return ()
@@ -130,6 +138,21 @@ def read_open_orders(path: Path = OPEN_ORDERS_PATH) -> tuple[OpenOrder, ...]:
     return tuple(orders)
 
 
+def read_account(path: Path = ACCOUNT_PATH) -> AccountState:
+    if not path.exists():
+        return AccountState()
+    rows = _read_csv_rows(path, {"key", "value"})
+    values: dict[str, float] = {}
+    for row in rows:
+        key = row["key"].strip().lower()
+        if key in {"cash", "account_value"}:
+            values[key] = _parse_float(row["value"], f"{path}: value for {key}")
+    return AccountState(
+        cash=values.get("cash"),
+        account_value=values.get("account_value"),
+    )
+
+
 def latest_market_prices(market_dir: Path = MARKET_DIR) -> dict[str, float]:
     if not market_dir.exists():
         return {}
@@ -145,12 +168,16 @@ def build_portfolio_state(
     *,
     positions_path: Path = POSITIONS_PATH,
     open_orders_path: Path = OPEN_ORDERS_PATH,
+    account_path: Path = ACCOUNT_PATH,
     market_dir: Path = MARKET_DIR,
     account_value: float | None = None,
     cash: float | None = None,
 ) -> PortfolioState:
     positions = read_positions(positions_path)
     open_orders = read_open_orders(open_orders_path)
+    account = read_account(account_path)
+    resolved_account_value = account_value if account_value is not None else account.account_value
+    resolved_cash = cash if cash is not None else account.cash
     prices = latest_market_prices(market_dir)
     warnings: list[str] = []
 
@@ -181,8 +208,10 @@ def build_portfolio_state(
         post_fill_quantity = quantity + pending_buy_quantity - pending_sell_quantity
         post_fill_value = post_fill_quantity * price if price is not None else None
         allocation_pct = (
-            market_value / account_value
-            if market_value is not None and account_value is not None and account_value > 0
+            market_value / resolved_account_value
+            if market_value is not None
+            and resolved_account_value is not None
+            and resolved_account_value > 0
             else None
         )
 
@@ -205,8 +234,8 @@ def build_portfolio_state(
         open_orders=open_orders,
         symbols=symbol_states,
         prices=prices,
-        account_value=account_value,
-        cash=cash,
+        account_value=resolved_account_value,
+        cash=resolved_cash,
         warnings=tuple(warnings),
     )
 
@@ -251,8 +280,18 @@ def summarize_portfolio_state(state: PortfolioState) -> str:
 def portfolio_files_exist(
     positions_path: Path = POSITIONS_PATH,
     open_orders_path: Path = OPEN_ORDERS_PATH,
+    account_path: Path = ACCOUNT_PATH,
 ) -> bool:
-    return positions_path.exists() or open_orders_path.exists()
+    return positions_path.exists() or open_orders_path.exists() or account_path.exists()
+
+
+def collect_portfolio_symbols(
+    positions_path: Path = POSITIONS_PATH,
+    open_orders_path: Path = OPEN_ORDERS_PATH,
+) -> list[str]:
+    symbols = {position.symbol for position in read_positions(positions_path)}
+    symbols.update(order.symbol for order in read_open_orders(open_orders_path))
+    return sorted(symbols)
 
 
 def write_position(path: Path, symbol: str, quantity: float) -> None:
@@ -283,6 +322,40 @@ def write_position(path: Path, symbol: str, quantity: float) -> None:
     _write_csv(path, POSITION_COLUMNS, rows)
 
 
+def update_position_quantity(
+    path: Path,
+    symbol: str,
+    delta: float,
+    *,
+    allow_negative: bool = False,
+) -> tuple[float, float]:
+    before = _position_quantity(path, symbol)
+    after = before + delta
+    if after < 0 and not allow_negative:
+        raise ValueError(
+            f"Local-only sell would make {symbol.strip().upper()} negative "
+            f"({after:g}); pass --allow-negative to permit it."
+        )
+    write_position(path, symbol, after)
+    return before, after
+
+
+def write_account_value(path: Path, key: str, value: float) -> None:
+    normalized = key.strip().lower().replace("-", "_")
+    if normalized not in {"cash", "account_value"}:
+        raise ValueError("account key must be cash or account_value")
+    rows = [dict(row) for row in _read_csv_rows(path, set(), allow_missing=True)]
+    today = date.today().isoformat()
+    found = False
+    for row in rows:
+        if row.get("key", "").strip().lower() == normalized:
+            row.update({"key": normalized, "value": str(value), "updated_at": today})
+            found = True
+    if not found:
+        rows.append({"key": normalized, "value": str(value), "updated_at": today})
+    _write_csv(path, ACCOUNT_COLUMNS, rows)
+
+
 def append_open_order(
     path: Path,
     *,
@@ -309,6 +382,33 @@ def append_open_order(
         }
     )
     _write_csv(path, OPEN_ORDER_COLUMNS, rows)
+
+
+def clear_open_orders(path: Path, symbol: str | None = None) -> int:
+    rows = [dict(row) for row in _read_csv_rows(path, set(), allow_missing=True)]
+    if not rows:
+        _write_csv(path, OPEN_ORDER_COLUMNS, rows)
+        return 0
+    today = date.today().isoformat()
+    cleared = 0
+    target = symbol.strip().upper() if symbol is not None else None
+    for row in rows:
+        row_symbol = row.get("symbol", "").strip().upper()
+        status = row.get("status", "").strip().lower()
+        if status == "canceled":
+            continue
+        if target is None or row_symbol == target:
+            row["status"] = "canceled"
+            row["notes"] = row.get("notes", "") or "locally_canceled"
+            row["submitted_at"] = row.get("submitted_at", "") or today
+            cleared += 1
+    _write_csv(path, OPEN_ORDER_COLUMNS, rows)
+    return cleared
+
+
+def _position_quantity(path: Path, symbol: str) -> float:
+    target = symbol.strip().upper()
+    return sum(position.quantity for position in read_positions(path) if position.symbol == target)
 
 
 def _read_csv_rows(

--- a/src/trading_lab/signals/orders.py
+++ b/src/trading_lab/signals/orders.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from trading_lab.config import TradingConfig, load_trading_config
 from trading_lab.signals.ladder import LadderOrder
+from trading_lab.portfolio.state import OPEN_ORDERS_PATH
 
 
 @dataclass(frozen=True)
@@ -203,7 +204,7 @@ def main() -> None:
     from trading_lab.signals.ladder import build_tqqq_ladder
 
     parser = ArgumentParser()
-    parser.add_argument("--orders", default="data/manual/open_orders.csv")
+    parser.add_argument("--orders")
     parser.add_argument("--account", default="config/account.yaml")
     parser.add_argument("--config", default="config/trading.yaml")
     args = parser.parse_args()
@@ -211,7 +212,13 @@ def main() -> None:
     trading_cfg = load_trading_config(Path(args.config))
     cols = TradingColumns(trading_cfg)
 
-    orders_path = Path(args.orders)
+    portfolio_orders_path = OPEN_ORDERS_PATH
+    if args.orders:
+        orders_path = Path(args.orders)
+    elif portfolio_orders_path.exists():
+        orders_path = portfolio_orders_path
+    else:
+        orders_path = Path("data/manual/open_orders.csv")
     account_path = Path(args.account)
 
     if account_path.exists():

--- a/src/trading_lab/workflows/full_daily.py
+++ b/src/trading_lab/workflows/full_daily.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import sys
 
+from trading_lab.portfolio.state import OPEN_ORDERS_PATH
 from trading_lab.workflows.commands import CommandRunner, py
 from trading_lab.workflows.daily import DailyWorkflow
 
@@ -17,7 +19,15 @@ class FullDailyWorkflow:
 
         DailyWorkflow(runner=self.runner).run()
 
-        self.runner.run("Parse open orders", py("scripts/parse_open_orders.py"))
+        if OPEN_ORDERS_PATH.exists():
+            print()
+            print(f"== Using local portfolio open orders: {OPEN_ORDERS_PATH} ==")
+        else:
+            self.runner.run("Parse open orders", py("scripts/parse_open_orders.py"))
+        self.runner.run(
+            "Portfolio status",
+            [sys.executable, "-m", "trading_lab.cli.main", "portfolio", "status"],
+        )
         self.runner.run("Reconcile orders", py("scripts/reconcile_orders.py"))
 
         print()

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -130,6 +130,11 @@ def test_decision_warns_when_local_portfolio_pending_exceeds_max_allocation(tmp_
     assert "Worst-case if all buys fill: $820.00 (16.4%)." in text
     assert "Pending orders exceed max recommended allocation: YES." in text
     assert "Portfolio action: cancel/reduce orders." in text
+    assert "Advice and Interpretation:" in text
+    assert text.index("Advice and Interpretation:") < text.index("Open-order review:")
+    assert "Do not add new TQQQ buys now." in text
+    assert "Suggested order ideas:" in text
+    assert "No new buy orders. Cancel/reduce existing buys first." in text
     assert "Portfolio holdings review:" in text
     assert "Open-order review:" in text
     assert "CANCEL TQQQ buy" in text or "REDUCE TQQQ buy" in text

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -141,6 +141,39 @@ def test_decision_warns_when_local_portfolio_pending_exceeds_max_allocation(tmp_
     assert "REVIEW TQQQ sell" in text or "KEEP TQQQ sell" in text
 
 
+def test_decision_risk_mode_aggressive_keeps_deep_buy_under_review(tmp_path):
+    reports = _write_reports(tmp_path)
+    portfolio_dir = tmp_path / "data" / "raw" / "portfolio"
+    market_dir = tmp_path / "data" / "raw" / "market"
+    portfolio_dir.mkdir(parents=True)
+    market_dir.mkdir(parents=True)
+    (portfolio_dir / "positions.csv").write_text(
+        "symbol,quantity,notes,updated_at\nTQQQ,4,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+    (portfolio_dir / "open_orders.csv").write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n"
+        "TQQQ,buy,limit,1,60.00,GTC,placed,2026-04-29,shallow\n"
+        "TQQQ,buy,limit,1,52.00,GTC,placed,2026-04-29,deep\n",
+        encoding="utf-8",
+    )
+    (market_dir / "TQQQ.csv").write_text("date,close\n2026-05-04,60.00\n", encoding="utf-8")
+
+    text = render_daily_decision(
+        reports_dir=reports,
+        positions_path=portfolio_dir / "positions.csv",
+        open_orders_path=portfolio_dir / "open_orders.csv",
+        market_dir=market_dir,
+        account_value=5000,
+        risk_mode="aggressive",
+    )
+
+    assert "Risk mode: aggressive" in text
+    assert "Aggressive mode accepts higher drawdown risk." in text
+    assert "Exposure warning:" in text
+    assert "REVIEW TQQQ buy 1 @ $52.00" in text
+
+
 def test_decision_missing_portfolio_files_do_not_break_decide(tmp_path):
     reports = _write_reports(tmp_path)
 
@@ -195,13 +228,25 @@ def test_cli_decide_does_not_invoke_workflow_commands(tmp_path, monkeypatch, cap
     monkeypatch.setattr(
         sys,
         "argv",
-        ["tl", "decide", "--account-value", "5000", "--position", "TQQQ:2", "--cash", "1200"],
+        [
+            "tl",
+            "decide",
+            "--account-value",
+            "5000",
+            "--position",
+            "TQQQ:2",
+            "--cash",
+            "1200",
+            "--risk-mode",
+            "balanced",
+        ],
     )
 
     cli_main.main()
 
     captured = capsys.readouterr()
     assert captured.out.startswith("ACTION: HOLD")
+    assert "Risk mode: balanced" in captured.out
     assert "daily workflow" not in captured.out.lower()
 
 

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -97,6 +97,56 @@ def test_decision_accounts_for_existing_position(tmp_path):
     assert "Already holding: yes, 2 shares of TQQQ, about $120.00." in text
 
 
+def test_decision_warns_when_local_portfolio_pending_exceeds_max_allocation(tmp_path):
+    reports = _write_reports(tmp_path)
+    portfolio_dir = tmp_path / "data" / "raw" / "portfolio"
+    market_dir = tmp_path / "data" / "raw" / "market"
+    portfolio_dir.mkdir(parents=True)
+    market_dir.mkdir(parents=True)
+    (portfolio_dir / "positions.csv").write_text(
+        "symbol,quantity,notes,updated_at\nTQQQ,4,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+    (portfolio_dir / "open_orders.csv").write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n"
+        "TQQQ,buy,limit,10,58.00,GTC,placed,2026-04-29,current_open_order\n"
+        "TQQQ,sell,limit,4,68.50,GTC,placed,2026-04-29,current_open_order\n",
+        encoding="utf-8",
+    )
+    (market_dir / "TQQQ.csv").write_text("date,close\n2026-05-04,60.00\n", encoding="utf-8")
+
+    text = render_daily_decision(
+        reports_dir=reports,
+        positions_path=portfolio_dir / "positions.csv",
+        open_orders_path=portfolio_dir / "open_orders.csv",
+        market_dir=market_dir,
+        account_value=5000,
+    )
+
+    assert "Current TQQQ position: 4 shares." in text
+    assert "Current TQQQ market value: $240.00 (4.8%)." in text
+    assert "Pending buy orders: 10 shares, $580.00." in text
+    assert "Pending sell orders: 4 shares, $274.00." in text
+    assert "Worst-case if all buys fill: $820.00 (16.4%)." in text
+    assert "Pending orders exceed max recommended allocation: YES." in text
+    assert "Portfolio action: cancel/reduce orders." in text
+
+
+def test_decision_missing_portfolio_files_do_not_break_decide(tmp_path):
+    reports = _write_reports(tmp_path)
+
+    text = render_daily_decision(
+        reports_dir=reports,
+        positions_path=tmp_path / "missing_positions.csv",
+        open_orders_path=tmp_path / "missing_orders.csv",
+        market_dir=tmp_path / "missing_market",
+        account_value=5000,
+    )
+
+    assert text.startswith("ACTION: WAIT")
+    assert "Portfolio state:" not in text
+
+
 def test_cli_decide_does_not_invoke_workflow_commands(tmp_path, monkeypatch, capsys):
     _write_reports(tmp_path)
     monkeypatch.chdir(tmp_path)

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -147,6 +147,32 @@ def test_decision_missing_portfolio_files_do_not_break_decide(tmp_path):
     assert "Portfolio state:" not in text
 
 
+def test_decide_reads_saved_account_csv_and_flags_override(tmp_path):
+    reports = _write_reports(tmp_path)
+    portfolio_dir = tmp_path / "data" / "raw" / "portfolio"
+    portfolio_dir.mkdir(parents=True)
+    account_path = portfolio_dir / "account.csv"
+    account_path.write_text(
+        "key,value,updated_at\n"
+        "cash,1624.35,2026-05-04\n"
+        "account_value,5000,2026-05-04\n",
+        encoding="utf-8",
+    )
+
+    saved = render_daily_decision(reports_dir=reports)
+    overridden = render_daily_decision(
+        reports_dir=reports,
+        cash=250,
+        account_value=10000,
+    )
+
+    assert "Account value: $5,000.00" in saved
+    assert "Cash: $1,624.35" in saved
+    assert "In cash: yes, $1,624.35 supplied." in saved
+    assert "Account value: $10,000.00" in overridden
+    assert "Cash: $250.00" in overridden
+
+
 def test_cli_decide_does_not_invoke_workflow_commands(tmp_path, monkeypatch, capsys):
     _write_reports(tmp_path)
     monkeypatch.chdir(tmp_path)

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -130,6 +130,10 @@ def test_decision_warns_when_local_portfolio_pending_exceeds_max_allocation(tmp_
     assert "Worst-case if all buys fill: $820.00 (16.4%)." in text
     assert "Pending orders exceed max recommended allocation: YES." in text
     assert "Portfolio action: cancel/reduce orders." in text
+    assert "Portfolio holdings review:" in text
+    assert "Open-order review:" in text
+    assert "CANCEL TQQQ buy" in text or "REDUCE TQQQ buy" in text
+    assert "REVIEW TQQQ sell" in text or "KEEP TQQQ sell" in text
 
 
 def test_decision_missing_portfolio_files_do_not_break_decide(tmp_path):

--- a/tests/test_market_update_freshness.py
+++ b/tests/test_market_update_freshness.py
@@ -5,7 +5,7 @@ import time
 
 import pandas as pd
 
-from trading_lab.data.market import csv_has_today_data, update_market_data
+from trading_lab.data.market import csv_has_today_data, market_symbol_universe, update_market_data
 
 
 def _set_mtime(path: Path, day: date) -> None:
@@ -43,3 +43,33 @@ def test_update_market_data_skips_fresh_files_without_downloading(tmp_path: Path
     result = update_market_data(symbols=["TQQQ"], out_dir=out_dir)
 
     assert result == {"downloaded": 0, "skipped": 1, "failed": 0}
+
+
+def test_market_symbol_universe_includes_local_portfolio_symbols(tmp_path: Path, monkeypatch):
+    portfolio_dir = tmp_path / "data" / "raw" / "portfolio"
+    portfolio_dir.mkdir(parents=True)
+    (portfolio_dir / "positions.csv").write_text(
+        "symbol,quantity,notes,updated_at\n"
+        "APLD,1,current_position,2026-05-04\n"
+        "APP,1,current_position,2026-05-04\n"
+        "CRWV,1,current_position,2026-05-04\n"
+        "DDOG,1,current_position,2026-05-04\n"
+        "EQIX,1,current_position,2026-05-04\n"
+        "SNDK,1,current_position,2026-05-04\n"
+        "SNOW,1,current_position,2026-05-04\n"
+        "STX,1,current_position,2026-05-04\n"
+        "TSM,1,current_position,2026-05-04\n"
+        "VST,1,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+    (portfolio_dir / "open_orders.csv").write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n"
+        "TQQQ,buy,limit,1,58,GTC,placed,2026-05-04,current_open_order\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    symbols = market_symbol_universe(config_symbols=["SPY"])
+
+    for symbol in ["SPY", "APLD", "APP", "CRWV", "DDOG", "EQIX", "SNDK", "SNOW", "STX", "TSM", "VST", "TQQQ"]:
+        assert symbol in symbols

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -65,6 +65,14 @@ def test_gui_render_includes_local_status_and_forms(tmp_path: Path, monkeypatch)
     assert "TQQQ" in html
     assert "/position/set" in html
     assert "/order/add" in html
+    assert 'data-tab="daily"' in html
+    assert 'data-tab="positions"' in html
+    assert 'data-tab="orders"' in html
+    assert 'data-tab="edit"' in html
+    assert ">Daily</button>" in html
+    assert ">Positions</button>" in html
+    assert ">Open orders</button>" in html
+    assert ">Edit local CSVs</button>" in html
 
 
 def test_gui_contains_daily_decision_dark_css_dates_and_saved_account(tmp_path, monkeypatch):
@@ -74,6 +82,10 @@ def test_gui_contains_daily_decision_dark_css_dates_and_saved_account(tmp_path, 
     html = render_status_page()
 
     assert "Daily decision" in html
+    assert 'id="tab-daily"' in html
+    assert "Portfolio summary" in html
+    assert "Dates and updates" in html
+    assert "mini-scroll" in html
     assert "ACTION" not in html
     assert "HOLD" in html
     assert "background: radial-gradient" in html
@@ -104,6 +116,8 @@ def test_gui_has_live_clock_hourly_refresh_and_scrollable_tables(tmp_path, monke
     assert "resize: vertical" in html
     assert "overflow-y: auto" in html
     assert "position: sticky" in html
+    assert "tab-panel active" in html
+    assert "button.dataset.tab" in html
 
 
 def test_gui_render_does_not_invoke_full_daily_workflow(tmp_path, monkeypatch):
@@ -120,20 +134,54 @@ def test_gui_render_does_not_invoke_full_daily_workflow(tmp_path, monkeypatch):
     assert "Trading Lab" in render_status_page()
 
 
-def test_gui_shows_holdings_and_order_recommendations(tmp_path, monkeypatch):
+def test_gui_combines_positions_with_holdings_review(tmp_path, monkeypatch):
     _write_dashboard_fixture(tmp_path)
     monkeypatch.chdir(tmp_path)
 
     html = render_status_page()
 
-    assert "Portfolio holdings review" in html
+    assert 'id="tab-positions"' in html
     assert "META" in html
+    assert "Review status" in html
+    assert "Review note" in html
     assert "OK_SMALL" in html
     assert "PRICE_MISSING" in html
-    assert "Open-order recommendations" in html
+    assert "Portfolio holdings review" not in html
+    assert "No model-backed buy/sell predictions are claimed" in html
+
+
+def test_gui_combines_open_orders_with_recommendations(tmp_path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    html = render_status_page()
+
+    assert 'id="tab-orders"' in html
+    assert "Recommendation" in html
+    assert "Price relation" in html
+    assert "Ladder relation" in html
+    assert "Projected exposure" in html
     assert "CANCEL" in html or "REDUCE" in html
+    assert "action-CANCEL" in html or "action-REDUCE" in html
+    assert "action-KEEP" in html
     assert "Sell order reduces" in html
     assert "No model signal" in html
+    assert "Open-order recommendations" not in html
+
+
+def test_gui_edit_tab_contains_local_csv_warning_and_forms(tmp_path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    html = render_status_page()
+
+    assert 'id="tab-edit"' in html
+    assert "Local CSV update only" in html
+    assert 'action="/account"' in html
+    assert 'action="/position/set"' in html
+    assert 'action="/position/update"' in html
+    assert 'action="/order/add"' in html
+    assert 'action="/order/clear"' in html
 
 
 def test_gui_apply_form_actions_edit_local_csvs(tmp_path: Path, monkeypatch):

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -29,12 +29,17 @@ def _write_dashboard_fixture(tmp_path: Path) -> None:
     market_dir.mkdir(parents=True)
     reports_dir.mkdir(parents=True)
     (portfolio_dir / "positions.csv").write_text(
-        "symbol,quantity,notes,updated_at\nTQQQ,4,current_position,2026-05-04\n",
+        "symbol,quantity,notes,updated_at\n"
+        "TQQQ,4,current_position,2026-05-04\n"
+        "META,0.04,current_position,2026-05-04\n"
+        "MISSING,1,current_position,2026-05-04\n",
         encoding="utf-8",
     )
     (portfolio_dir / "open_orders.csv").write_text(
         "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n"
-        "TQQQ,buy,limit,10,58.00,GTC,placed,2026-04-29,current_open_order\n",
+        "TQQQ,buy,limit,10,58.00,GTC,placed,2026-04-29,current_open_order\n"
+        "TQQQ,sell,limit,4,68.50,GTC,placed,2026-04-29,current_open_order\n"
+        "META,buy,limit,1,500.00,GTC,placed,2026-04-29,current_open_order\n",
         encoding="utf-8",
     )
     (portfolio_dir / "account.csv").write_text(
@@ -42,6 +47,7 @@ def _write_dashboard_fixture(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     (market_dir / "TQQQ.csv").write_text("date,close\n2026-05-04,60\n", encoding="utf-8")
+    (market_dir / "META.csv").write_text("date,close\n2026-05-04,600\n", encoding="utf-8")
     (reports_dir / "daily_decision_summary.txt").write_text(SUMMARY, encoding="utf-8")
     (reports_dir / "selected_model_latest_signal.csv").write_text(
         "date,model,probability\n2026-05-04,demo,0.58\n",
@@ -82,6 +88,52 @@ def test_gui_contains_daily_decision_dark_css_dates_and_saved_account(tmp_path, 
     assert "$1,624.35" in html
     assert "$5,000.00" in html
     assert "Local CSV update only" in html
+
+
+def test_gui_has_live_clock_hourly_refresh_and_scrollable_tables(tmp_path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    html = render_status_page()
+
+    assert "id=\"local-clock\"" in html
+    assert "id=\"last-refresh\"" in html
+    assert "setInterval(updateLocalClock, 1000)" in html
+    assert "60 * 60 * 1000" in html
+    assert "Local dashboard refreshes hourly from existing files" in html
+    assert "resize: vertical" in html
+    assert "overflow-y: auto" in html
+    assert "position: sticky" in html
+
+
+def test_gui_render_does_not_invoke_full_daily_workflow(tmp_path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    from trading_lab.workflows.daily import DailyWorkflow
+
+    def fail_run(self):
+        raise AssertionError("GUI must not run daily workflow")
+
+    monkeypatch.setattr(DailyWorkflow, "run", fail_run)
+
+    assert "Trading Lab" in render_status_page()
+
+
+def test_gui_shows_holdings_and_order_recommendations(tmp_path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    html = render_status_page()
+
+    assert "Portfolio holdings review" in html
+    assert "META" in html
+    assert "OK_SMALL" in html
+    assert "PRICE_MISSING" in html
+    assert "Open-order recommendations" in html
+    assert "CANCEL" in html or "REDUCE" in html
+    assert "Sell order reduces" in html
+    assert "No model signal" in html
 
 
 def test_gui_apply_form_actions_edit_local_csvs(tmp_path: Path, monkeypatch):

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from trading_lab.portfolio.gui import apply_form_action, render_status_page
+from trading_lab.portfolio.state import read_account, read_open_orders, read_positions
+
+
+def test_gui_render_includes_local_status_and_forms(tmp_path: Path, monkeypatch):
+    portfolio_dir = tmp_path / "data" / "raw" / "portfolio"
+    market_dir = tmp_path / "data" / "raw" / "market"
+    portfolio_dir.mkdir(parents=True)
+    market_dir.mkdir(parents=True)
+    (portfolio_dir / "positions.csv").write_text(
+        "symbol,quantity,notes,updated_at\nTQQQ,4,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+    (market_dir / "TQQQ.csv").write_text("date,close\n2026-05-04,60\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    html = render_status_page()
+
+    assert "Local portfolio" in html
+    assert "TQQQ" in html
+    assert "/position/set" in html
+    assert "/order/add" in html
+
+
+def test_gui_apply_form_actions_edit_local_csvs(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    assert apply_form_action("/account", {"cash": "1000", "account_value": "5000"})
+    assert apply_form_action("/position/set", {"symbol": "TQQQ", "quantity": "4"})
+    assert apply_form_action(
+        "/position/update",
+        {"side": "buy", "symbol": "TQQQ", "quantity": "1"},
+    )
+    assert apply_form_action(
+        "/order/add",
+        {"side": "buy", "symbol": "TQQQ", "quantity": "10", "limit_price": "58"},
+    )
+    assert apply_form_action("/order/clear", {"symbol": "TQQQ"})
+
+    assert read_account().cash == 1000
+    assert read_account().account_value == 5000
+    assert read_positions()[0].quantity == 5
+    assert read_open_orders()[0].status == "canceled"

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -79,6 +79,9 @@ def test_gui_render_includes_local_status_and_forms(tmp_path: Path, monkeypatch)
     assert 'data-risk-mode="balanced"' in html
     assert 'data-risk-mode="aggressive"' in html
     assert "risk-pill active" in html
+    assert "min-width: 320px" in html
+    assert "flex-wrap: wrap" in html
+    assert "white-space: nowrap" in html
 
 
 def test_gui_contains_daily_decision_dark_css_dates_and_saved_account(tmp_path, monkeypatch):
@@ -121,7 +124,7 @@ def test_gui_has_live_clock_hourly_refresh_and_scrollable_tables(tmp_path, monke
     assert "60 * 60 * 1000" in html
     assert "Local dashboard refreshes hourly from existing files" in html
     assert "resize: vertical" in html
-    assert "overflow-y: auto" in html
+    assert "overflow: auto" in html
     assert "position: sticky" in html
     assert "tab-panel active" in html
     assert "button.dataset.tab" in html
@@ -174,6 +177,11 @@ def test_gui_combines_open_orders_with_recommendations(tmp_path, monkeypatch):
     assert "Price relation" in html
     assert "Ladder relation" in html
     assert "Projected exposure" in html
+    assert 'class="open-orders-table"' in html
+    assert 'class="col-reason"' in html
+    assert 'class="reason-cell"' in html
+    assert "min-width: 1500px" in html
+    assert "min-width: 420px" in html
     assert "CANCEL" in html or "REDUCE" in html
     assert "action-CANCEL" in html or "action-REDUCE" in html
     assert "action-KEEP" in html

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -73,10 +73,12 @@ def test_gui_render_includes_local_status_and_forms(tmp_path: Path, monkeypatch)
     assert ">Positions</button>" in html
     assert ">Open orders</button>" in html
     assert ">Edit local CSVs</button>" in html
-    assert 'name="risk_mode"' in html
-    assert 'value="conservative" selected' in html
-    assert 'value="balanced"' in html
-    assert 'value="aggressive"' in html
+    assert "Global dashboard controls" in html
+    assert "risk-segmented" in html
+    assert 'data-risk-mode="conservative"' in html
+    assert 'data-risk-mode="balanced"' in html
+    assert 'data-risk-mode="aggressive"' in html
+    assert "risk-pill active" in html
 
 
 def test_gui_contains_daily_decision_dark_css_dates_and_saved_account(tmp_path, monkeypatch):
@@ -123,6 +125,12 @@ def test_gui_has_live_clock_hourly_refresh_and_scrollable_tables(tmp_path, monke
     assert "position: sticky" in html
     assert "tab-panel active" in html
     assert "button.dataset.tab" in html
+    assert "new URLSearchParams(window.location.search)" in html
+    assert "history.replaceState" in html
+    assert "tlPortfolioTab" in html
+    assert "tlPortfolioRiskMode" in html
+    assert "search.set('tab', dashboardState.tab)" in html
+    assert "search.set('risk_mode', dashboardState.riskMode)" in html
 
 
 def test_gui_render_does_not_invoke_full_daily_workflow(tmp_path, monkeypatch):
@@ -194,12 +202,30 @@ def test_gui_risk_mode_changes_recommendation_wording(tmp_path, monkeypatch):
     _write_dashboard_fixture(tmp_path)
     monkeypatch.chdir(tmp_path)
 
-    html = render_status_page(risk_mode="aggressive")
+    html = render_status_page(risk_mode="aggressive", active_tab="orders")
 
     assert "Aggressive mode accepts higher drawdown risk" in html
     assert "Trend-first advice" in html
-    assert 'value="aggressive" selected' in html
+    assert 'data-risk-mode="aggressive">Aggressive</button>' in html
+    assert 'aria-checked="true" data-risk-mode="aggressive"' in html
+    assert 'class="tab-button active" type="button" data-tab="orders"' in html
+    assert 'class="tab-panel active" id="tab-orders"' in html
     assert "Risk mode" in html
+
+
+def test_gui_risk_mode_is_global_and_persists_with_tabs(tmp_path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    html = render_status_page(risk_mode="balanced", active_tab="positions")
+
+    assert html.index("risk-segmented") < html.index('id="tab-daily"')
+    assert html.index("risk-segmented") < html.index('id="tab-positions"')
+    assert 'class="tab-button active" type="button" data-tab="positions"' in html
+    assert 'class="tab-panel active" id="tab-positions"' in html
+    assert 'aria-checked="true" data-risk-mode="balanced"' in html
+    assert "window.location.assign(next)" in html
+    assert "hydrateState()" in html
 
 
 def test_gui_edit_tab_contains_local_csv_warning_and_forms(tmp_path, monkeypatch):

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -73,6 +73,10 @@ def test_gui_render_includes_local_status_and_forms(tmp_path: Path, monkeypatch)
     assert ">Positions</button>" in html
     assert ">Open orders</button>" in html
     assert ">Edit local CSVs</button>" in html
+    assert 'name="risk_mode"' in html
+    assert 'value="conservative" selected' in html
+    assert 'value="balanced"' in html
+    assert 'value="aggressive"' in html
 
 
 def test_gui_contains_daily_decision_dark_css_dates_and_saved_account(tmp_path, monkeypatch):
@@ -184,6 +188,18 @@ def test_gui_advice_before_model_probability_and_spacing_css(tmp_path, monkeypat
     assert "current TQQQ exposure ($240.00)" in html or "Pending buy orders" in html
     assert "order-actions-card" in html
     assert "margin-top: 14px" in html
+
+
+def test_gui_risk_mode_changes_recommendation_wording(tmp_path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    html = render_status_page(risk_mode="aggressive")
+
+    assert "Aggressive mode accepts higher drawdown risk" in html
+    assert "Trend-first advice" in html
+    assert 'value="aggressive" selected' in html
+    assert "Risk mode" in html
 
 
 def test_gui_edit_tab_contains_local_csv_warning_and_forms(tmp_path, monkeypatch):

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -6,24 +6,82 @@ from trading_lab.portfolio.gui import apply_form_action, render_status_page
 from trading_lab.portfolio.state import read_account, read_open_orders, read_positions
 
 
-def test_gui_render_includes_local_status_and_forms(tmp_path: Path, monkeypatch):
+SUMMARY = """Date: 2026-05-04
+QQQ: 420.00
+TQQQ: 60.00
+Profile: default
+Active target column: TQQQ_target_5d_threshold_horizon_return
+Suggested action: WAIT_FOR_PULLBACK
+Max TQQQ allocation: 5%
+Selected strategy eligible today: NO
+- NO: selected model probability 0.580 < threshold 0.65
+
+Suggested TQQQ ladder:
+- shallow_pullback: limit $58.20, allocation 1.2%, synthetic.
+"""
+
+
+def _write_dashboard_fixture(tmp_path: Path) -> None:
     portfolio_dir = tmp_path / "data" / "raw" / "portfolio"
     market_dir = tmp_path / "data" / "raw" / "market"
+    reports_dir = tmp_path / "data" / "reports"
     portfolio_dir.mkdir(parents=True)
     market_dir.mkdir(parents=True)
+    reports_dir.mkdir(parents=True)
     (portfolio_dir / "positions.csv").write_text(
         "symbol,quantity,notes,updated_at\nTQQQ,4,current_position,2026-05-04\n",
         encoding="utf-8",
     )
+    (portfolio_dir / "open_orders.csv").write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n"
+        "TQQQ,buy,limit,10,58.00,GTC,placed,2026-04-29,current_open_order\n",
+        encoding="utf-8",
+    )
+    (portfolio_dir / "account.csv").write_text(
+        "key,value,updated_at\ncash,1624.35,2026-05-04\naccount_value,5000,2026-05-04\n",
+        encoding="utf-8",
+    )
     (market_dir / "TQQQ.csv").write_text("date,close\n2026-05-04,60\n", encoding="utf-8")
+    (reports_dir / "daily_decision_summary.txt").write_text(SUMMARY, encoding="utf-8")
+    (reports_dir / "selected_model_latest_signal.csv").write_text(
+        "date,model,probability\n2026-05-04,demo,0.58\n",
+        encoding="utf-8",
+    )
+
+
+def test_gui_render_includes_local_status_and_forms(tmp_path: Path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
     monkeypatch.chdir(tmp_path)
 
     html = render_status_page()
 
-    assert "Local portfolio" in html
+    assert "Trading Lab" in html
     assert "TQQQ" in html
     assert "/position/set" in html
     assert "/order/add" in html
+
+
+def test_gui_contains_daily_decision_dark_css_dates_and_saved_account(tmp_path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    html = render_status_page()
+
+    assert "Daily decision" in html
+    assert "ACTION" not in html
+    assert "HOLD" in html
+    assert "background: radial-gradient" in html
+    assert "color-scheme: dark" in html
+    assert "href=" not in html
+    assert "src=" not in html
+    assert "positions.csv modified" in html
+    assert "open_orders.csv modified" in html
+    assert "account.csv modified" in html
+    assert "Market CSV date" in html
+    assert "2026-05-04" in html
+    assert "$1,624.35" in html
+    assert "$5,000.00" in html
+    assert "Local CSV update only" in html
 
 
 def test_gui_apply_form_actions_edit_local_csvs(tmp_path: Path, monkeypatch):

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -95,6 +95,7 @@ def test_gui_contains_daily_decision_dark_css_dates_and_saved_account(tmp_path, 
     assert "positions.csv modified" in html
     assert "open_orders.csv modified" in html
     assert "account.csv modified" in html
+    assert "Report updated" in html
     assert "Market CSV date" in html
     assert "2026-05-04" in html
     assert "$1,624.35" in html
@@ -166,7 +167,23 @@ def test_gui_combines_open_orders_with_recommendations(tmp_path, monkeypatch):
     assert "action-KEEP" in html
     assert "Sell order reduces" in html
     assert "No model signal" in html
+    assert "Suggested order ideas" in html
+    assert "No new buy orders. Cancel/reduce existing buys first." in html
+    assert "Keep/review the TQQQ sell 4 @ $68.50" in html
     assert "Open-order recommendations" not in html
+
+
+def test_gui_advice_before_model_probability_and_spacing_css(tmp_path, monkeypatch):
+    _write_dashboard_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    html = render_status_page()
+
+    assert "Advice and Interpretation" in html
+    assert html.index("Advice and Interpretation") < html.index("Model probability")
+    assert "current TQQQ exposure ($240.00)" in html or "Pending buy orders" in html
+    assert "order-actions-card" in html
+    assert "margin-top: 14px" in html
 
 
 def test_gui_edit_tab_contains_local_csv_warning_and_forms(tmp_path, monkeypatch):

--- a/tests/test_portfolio_review.py
+++ b/tests/test_portfolio_review.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from trading_lab.portfolio.review import review_holdings, review_open_orders
+from trading_lab.portfolio.state import OpenOrder, PortfolioState, SymbolPortfolioState
+
+
+def test_non_traded_holdings_review_statuses():
+    state = PortfolioState(
+        symbols={
+            "TQQQ": SymbolPortfolioState(symbol="TQQQ", quantity=4, allocation_pct=0.05),
+            "META": SymbolPortfolioState(
+                symbol="META",
+                quantity=0.04,
+                latest_price=600,
+                market_value=24,
+                allocation_pct=0.0048,
+            ),
+            "BIG": SymbolPortfolioState(
+                symbol="BIG",
+                quantity=10,
+                latest_price=50,
+                market_value=500,
+                allocation_pct=0.10,
+            ),
+            "MISS": SymbolPortfolioState(symbol="MISS", quantity=1),
+        }
+    )
+
+    reviews = {row.symbol: row for row in review_holdings(state, "TQQQ")}
+
+    assert reviews["META"].status == "OK_SMALL"
+    assert reviews["BIG"].status == "REVIEW_SIZE"
+    assert reviews["MISS"].status == "PRICE_MISSING"
+
+
+def test_order_review_marks_over_capacity_buys_cancel_or_reduce_and_sell_not_aggressive():
+    state = PortfolioState(
+        account_value=5000,
+        symbols={
+            "TQQQ": SymbolPortfolioState(
+                symbol="TQQQ",
+                quantity=4,
+                latest_price=60,
+                market_value=240,
+            )
+        },
+        open_orders=(
+            OpenOrder("TQQQ", "buy", "limit", 10, 58, "GTC", "placed", "2026-05-04"),
+            OpenOrder("TQQQ", "sell", "limit", 4, 68.50, "GTC", "placed", "2026-05-04"),
+        ),
+    )
+
+    reviews = review_open_orders(
+        state,
+        "TQQQ",
+        account_value=5000,
+        max_allocation=0.05,
+        suggested_action="WAIT_FOR_PULLBACK",
+        strategy_eligible=False,
+        ladder=("shallow_pullback: limit $58.20, allocation 1.2%, synthetic.",),
+    )
+
+    buy = [row for row in reviews if row.side == "buy"][0]
+    sell = [row for row in reviews if row.side == "sell"][0]
+
+    assert buy.recommended_action in {"CANCEL", "REDUCE"}
+    assert sell.recommended_action in {"KEEP", "REVIEW"}
+    assert sell.recommended_action not in {"CANCEL", "REDUCE", "MOVE_LOWER"}

--- a/tests/test_portfolio_review.py
+++ b/tests/test_portfolio_review.py
@@ -64,5 +64,7 @@ def test_order_review_marks_over_capacity_buys_cancel_or_reduce_and_sell_not_agg
     sell = [row for row in reviews if row.side == "sell"][0]
 
     assert buy.recommended_action in {"CANCEL", "REDUCE"}
+    assert "order notional $580.00 exceeds remaining buy capacity $10.00" in buy.reason
+    assert "projected exposure would be $820.00" in buy.reason
     assert sell.recommended_action in {"KEEP", "REVIEW"}
     assert sell.recommended_action not in {"CANCEL", "REDUCE", "MOVE_LOWER"}

--- a/tests/test_portfolio_review.py
+++ b/tests/test_portfolio_review.py
@@ -68,3 +68,69 @@ def test_order_review_marks_over_capacity_buys_cancel_or_reduce_and_sell_not_agg
     assert "projected exposure would be $820.00" in buy.reason
     assert sell.recommended_action in {"KEEP", "REVIEW"}
     assert sell.recommended_action not in {"CANCEL", "REDUCE", "MOVE_LOWER"}
+
+
+def test_balanced_mode_cancels_shallow_buys_but_reviews_deeper_buys():
+    state = PortfolioState(
+        account_value=5000,
+        symbols={
+            "TQQQ": SymbolPortfolioState(
+                symbol="TQQQ",
+                quantity=4,
+                latest_price=60,
+                market_value=260,
+            )
+        },
+        open_orders=(
+            OpenOrder("TQQQ", "buy", "limit", 1, 60, "GTC", "placed", "2026-05-04"),
+            OpenOrder("TQQQ", "buy", "limit", 1, 52, "GTC", "placed", "2026-05-04"),
+        ),
+    )
+
+    reviews = review_open_orders(
+        state,
+        "TQQQ",
+        account_value=5000,
+        max_allocation=0.05,
+        suggested_action="WAIT_FOR_PULLBACK",
+        strategy_eligible=False,
+        ladder=("shallow_pullback: limit $58.20, allocation 1.2%, synthetic.",),
+        risk_mode="balanced",
+    )
+
+    assert reviews[0].recommended_action in {"CANCEL", "REDUCE"}
+    assert reviews[1].recommended_action == "REVIEW"
+
+
+def test_aggressive_mode_reviews_deep_buys_while_warning_about_exposure():
+    state = PortfolioState(
+        account_value=5000,
+        symbols={
+            "TQQQ": SymbolPortfolioState(
+                symbol="TQQQ",
+                quantity=4,
+                latest_price=60,
+                market_value=260,
+            )
+        },
+        open_orders=(
+            OpenOrder("TQQQ", "buy", "limit", 1, 60, "GTC", "placed", "2026-05-04"),
+            OpenOrder("TQQQ", "buy", "limit", 1, 52, "GTC", "placed", "2026-05-04"),
+        ),
+    )
+
+    reviews = review_open_orders(
+        state,
+        "TQQQ",
+        account_value=5000,
+        max_allocation=0.05,
+        suggested_action="WAIT_FOR_PULLBACK",
+        strategy_eligible=False,
+        ladder=("shallow_pullback: limit $58.20, allocation 1.2%, synthetic.",),
+        risk_mode="aggressive",
+    )
+
+    assert reviews[0].recommended_action in {"REDUCE", "MOVE_LOWER"}
+    assert reviews[1].recommended_action == "REVIEW"
+    assert "Aggressive mode accepts higher drawdown risk" in reviews[1].reason
+    assert "Exposure warning" in reviews[1].reason

--- a/tests/test_portfolio_state.py
+++ b/tests/test_portfolio_state.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import inspect
+import pytest
+
+from trading_lab.portfolio import state
+from trading_lab.portfolio.state import (
+    build_portfolio_state,
+    latest_market_prices,
+    read_open_orders,
+    read_positions,
+)
+
+
+def test_read_positions_csv_without_prices_stored(tmp_path: Path):
+    path = tmp_path / "positions.csv"
+    path.write_text(
+        "symbol,quantity,notes,updated_at\n"
+        "TQQQ,4,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+
+    positions = read_positions(path)
+
+    assert positions[0].symbol == "TQQQ"
+    assert positions[0].quantity == 4
+    assert not hasattr(positions[0], "price")
+
+
+def test_read_open_orders_csv(tmp_path: Path):
+    path = tmp_path / "open_orders.csv"
+    path.write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n"
+        "TQQQ,buy,limit,10,58.00,GTC,placed,2026-04-29,current_open_order\n",
+        encoding="utf-8",
+    )
+
+    orders = read_open_orders(path)
+
+    assert orders[0].symbol == "TQQQ"
+    assert orders[0].side == "buy"
+    assert orders[0].exposure == 580
+
+
+def test_calculates_values_from_synthetic_market_csvs(tmp_path: Path):
+    portfolio_dir = tmp_path / "portfolio"
+    market_dir = tmp_path / "market"
+    portfolio_dir.mkdir()
+    market_dir.mkdir()
+    (portfolio_dir / "positions.csv").write_text(
+        "symbol,quantity,notes,updated_at\nTQQQ,4,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+    (portfolio_dir / "open_orders.csv").write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n",
+        encoding="utf-8",
+    )
+    (market_dir / "TQQQ.csv").write_text(
+        "date,close\n2026-05-01,60.00\n2026-05-04,62.50\n",
+        encoding="utf-8",
+    )
+
+    prices = latest_market_prices(market_dir)
+    result = build_portfolio_state(
+        positions_path=portfolio_dir / "positions.csv",
+        open_orders_path=portfolio_dir / "open_orders.csv",
+        market_dir=market_dir,
+        account_value=5000,
+    )
+
+    assert prices["TQQQ"] == 62.5
+    assert result.symbols["TQQQ"].market_value == 250
+    assert result.symbols["TQQQ"].allocation_pct == pytest.approx(0.05)
+
+
+def test_pending_tqqq_buy_and_sell_exposure_are_included(tmp_path: Path):
+    portfolio_dir = tmp_path / "portfolio"
+    market_dir = tmp_path / "market"
+    portfolio_dir.mkdir()
+    market_dir.mkdir()
+    (portfolio_dir / "positions.csv").write_text(
+        "symbol,quantity,notes,updated_at\nTQQQ,4,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+    (portfolio_dir / "open_orders.csv").write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n"
+        "TQQQ,buy,limit,10,58.00,GTC,placed,2026-04-29,current_open_order\n"
+        "TQQQ,sell,limit,4,68.50,GTC,placed,2026-04-29,current_open_order\n",
+        encoding="utf-8",
+    )
+    (market_dir / "TQQQ.csv").write_text("date,close\n2026-05-04,60.00\n", encoding="utf-8")
+
+    result = build_portfolio_state(
+        positions_path=portfolio_dir / "positions.csv",
+        open_orders_path=portfolio_dir / "open_orders.csv",
+        market_dir=market_dir,
+        account_value=5000,
+    )
+    tqqq = result.symbols["TQQQ"]
+
+    assert tqqq.pending_buy_quantity == 10
+    assert tqqq.pending_buy_value == 580
+    assert tqqq.pending_sell_quantity == 4
+    assert tqqq.pending_sell_value == 274
+    assert tqqq.post_fill_quantity == 10
+
+
+def test_missing_portfolio_files_produce_empty_state(tmp_path: Path):
+    result = build_portfolio_state(
+        positions_path=tmp_path / "missing_positions.csv",
+        open_orders_path=tmp_path / "missing_orders.csv",
+        market_dir=tmp_path / "market",
+    )
+
+    assert result.positions == ()
+    assert result.open_orders == ()
+    assert result.symbols == {}
+
+
+def test_invalid_required_columns_raise_clear_value_error(tmp_path: Path):
+    path = tmp_path / "positions.csv"
+    path.write_text("symbol,notes\nTQQQ,current_position\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Missing required columns"):
+        read_positions(path)
+
+
+def test_portfolio_module_has_no_broker_or_order_placement_functions():
+    source = inspect.getsource(state).lower()
+
+    assert "robinhood" not in source
+    assert "broker" not in source
+    assert "place_order" not in source
+    assert "submit_order" not in source

--- a/tests/test_portfolio_state.py
+++ b/tests/test_portfolio_state.py
@@ -7,10 +7,19 @@ import pytest
 
 from trading_lab.portfolio import state
 from trading_lab.portfolio.state import (
+    ACCOUNT_PATH,
+    OPEN_ORDERS_PATH,
+    POSITIONS_PATH,
+    append_open_order,
     build_portfolio_state,
+    clear_open_orders,
     latest_market_prices,
+    read_account,
     read_open_orders,
     read_positions,
+    update_position_quantity,
+    write_account_value,
+    write_position,
 )
 
 
@@ -134,3 +143,105 @@ def test_portfolio_module_has_no_broker_or_order_placement_functions():
     assert "broker" not in source
     assert "place_order" not in source
     assert "submit_order" not in source
+
+
+def test_update_buy_sell_set_modifies_positions(tmp_path: Path):
+    path = tmp_path / "positions.csv"
+
+    write_position(path, "TQQQ", 4)
+    before, after = update_position_quantity(path, "TQQQ", 1)
+    assert (before, after) == (4, 5)
+    before, after = update_position_quantity(path, "TQQQ", -1)
+    assert (before, after) == (5, 4)
+    write_position(path, "TQQQ", 7)
+
+    assert read_positions(path)[0].quantity == 7
+
+
+def test_sell_cannot_make_position_negative_by_default(tmp_path: Path):
+    path = tmp_path / "positions.csv"
+    write_position(path, "TQQQ", 1)
+
+    with pytest.raises(ValueError, match="negative"):
+        update_position_quantity(path, "TQQQ", -2)
+
+    assert read_positions(path)[0].quantity == 1
+    update_position_quantity(path, "TQQQ", -2, allow_negative=True)
+    assert read_positions(path)[0].quantity == -1
+
+
+def test_account_csv_cash_and_account_value_are_read_and_overridden(tmp_path: Path):
+    account_path = tmp_path / "account.csv"
+    positions_path = tmp_path / "positions.csv"
+    market_dir = tmp_path / "market"
+    market_dir.mkdir()
+    write_account_value(account_path, "cash", 1000)
+    write_account_value(account_path, "account_value", 5000)
+    write_position(positions_path, "TQQQ", 4)
+    (market_dir / "TQQQ.csv").write_text("date,close\n2026-05-04,50\n", encoding="utf-8")
+
+    account = read_account(account_path)
+    state_from_csv = build_portfolio_state(
+        positions_path=positions_path,
+        open_orders_path=tmp_path / "orders.csv",
+        account_path=account_path,
+        market_dir=market_dir,
+    )
+    overridden = build_portfolio_state(
+        positions_path=positions_path,
+        open_orders_path=tmp_path / "orders.csv",
+        account_path=account_path,
+        market_dir=market_dir,
+        account_value=10000,
+        cash=250,
+    )
+
+    assert account.cash == 1000
+    assert account.account_value == 5000
+    assert state_from_csv.cash == 1000
+    assert state_from_csv.account_value == 5000
+    assert state_from_csv.symbols["TQQQ"].allocation_pct == pytest.approx(0.04)
+    assert overridden.cash == 250
+    assert overridden.account_value == 10000
+    assert overridden.symbols["TQQQ"].allocation_pct == pytest.approx(0.02)
+
+
+def test_order_clear_and_clear_all_mark_orders_canceled(tmp_path: Path):
+    path = tmp_path / "open_orders.csv"
+    append_open_order(path, side="buy", symbol="TQQQ", quantity=1, limit_price=58)
+    append_open_order(path, side="sell", symbol="TQQQ", quantity=1, limit_price=68)
+    append_open_order(path, side="buy", symbol="APP", quantity=1, limit_price=10)
+
+    assert clear_open_orders(path, "TQQQ") == 2
+    orders = read_open_orders(path)
+    assert [order.status for order in orders if order.symbol == "TQQQ"] == ["canceled", "canceled"]
+    assert [order.status for order in orders if order.symbol == "APP"] == ["placed"]
+
+    assert clear_open_orders(path) == 1
+    assert all(order.status == "canceled" for order in read_open_orders(path))
+
+
+def test_cli_update_commands_modify_local_csvs(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+
+    import trading_lab.cli.main as cli_main
+
+    commands = [
+        ["tl", "update", "set", "TQQQ", "4"],
+        ["tl", "update", "buy", "TQQQ", "1"],
+        ["tl", "update", "sell", "TQQQ", "1"],
+        ["tl", "update", "cash", "1000"],
+        ["tl", "update", "account-value", "5000"],
+        ["tl", "update", "order", "buy", "TQQQ", "10", "58"],
+        ["tl", "update", "order", "sell", "TQQQ", "4", "68.50"],
+        ["tl", "update", "order", "clear", "TQQQ"],
+    ]
+    for argv in commands:
+        monkeypatch.setattr("sys.argv", argv)
+        cli_main.main()
+
+    assert read_positions(POSITIONS_PATH)[0].quantity == 4
+    assert read_account(ACCOUNT_PATH).cash == 1000
+    assert read_account(ACCOUNT_PATH).account_value == 5000
+    assert all(order.status == "canceled" for order in read_open_orders(OPEN_ORDERS_PATH))
+    assert "Local-only update" in capsys.readouterr().out


### PR DESCRIPTION
Adds local read-only portfolio and open-order state from gitignored data/raw/portfolio files, calculates current exposure from market data, and makes tl decide account for positions and pending limit orders without broker login or order placement.