### PR TITLE
Document local portfolio daily workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,17 +271,52 @@ python scripts/audit_repo.py
 python scripts/clean_cruft.py
 ```
 
-## Daily Use
+## Daily Workflow
 
-The normal daily flow is manual-first:
+The normal daily flow is manual-first and local-only. Use `tlfull` when you want the heavier refresh path that updates market/model reports, then use the lightweight commands for decision review and local portfolio state.
 
 ```bash
-./scripts/tl_full_daily.sh
-./scripts/tl_command.sh card
-./scripts/tl_command.sh decide --account-value 5000 --cash 1000 --position TQQQ:2
+tlfull
+tl decide
+tl portfolio status
+tl portfolio gui
 ```
 
-Use the output as decision support only. Review the model quality gate, selected strategy eligibility, current exposure, and open-order checks before making any manual trade.
+Risk mode changes the portfolio/order advice style without placing orders:
+
+```bash
+tl decide --risk-mode conservative
+tl decide --risk-mode balanced
+tl decide --risk-mode aggressive
+```
+
+Local account and portfolio edits update CSV files under `data/raw/portfolio/` only:
+
+```bash
+tl update cash AMOUNT
+tl update account-value AMOUNT
+tl update buy SYMBOL QTY
+tl update sell SYMBOL QTY
+tl update set SYMBOL QTY
+tl update order buy SYMBOL QTY LIMIT
+tl update order sell SYMBOL QTY LIMIT
+tl update order clear SYMBOL
+tl update order clear-all
+```
+
+A typical morning routine:
+
+```bash
+tlfull
+tl update cash 1000
+tl update account-value 5000
+tl decide --risk-mode balanced
+tl portfolio gui
+```
+
+Use the output as decision support only. Review the model quality gate, selected strategy eligibility, current exposure, and open-order checks before making any manual trade. The GUI only reads existing local files and edits local CSVs; it does not connect to a broker, log in to Robinhood, download prices, or place/cancel/modify real orders.
+
+See [docs/local_portfolio.md](docs/local_portfolio.md) for local portfolio CSV schemas, update commands, and risk-mode details.
 
 ## Configuration
 

--- a/docs/local_portfolio.md
+++ b/docs/local_portfolio.md
@@ -1,0 +1,135 @@
+# Local Portfolio Workflow
+
+`trading-lab` can read a small local portfolio snapshot so `tl decide`, `tl portfolio status`, and `tl portfolio gui` can account for current holdings, saved cash/account value, and manually tracked open orders.
+
+This is local decision support only:
+
+- `data/` is gitignored and should not be committed.
+- There is no broker connection.
+- There is no Robinhood login or broker API.
+- There is no automated order placement.
+- The browser GUI only edits local CSV files.
+- Market prices are read from local market CSVs under `data/raw/market/`; prices are not stored in `positions.csv`.
+
+## Daily Workflow
+
+Use `tlfull` for the heavy refresh path. It updates market data, features, models/reports, plots, and daily summaries. Use the other commands for lightweight review and local CSV edits.
+
+```bash
+tlfull
+tl decide
+tl portfolio status
+tl portfolio gui
+```
+
+Decision review supports risk modes:
+
+```bash
+tl decide --risk-mode conservative
+tl decide --risk-mode balanced
+tl decide --risk-mode aggressive
+```
+
+Local portfolio updates:
+
+```bash
+tl update cash AMOUNT
+tl update account-value AMOUNT
+tl update buy SYMBOL QTY
+tl update sell SYMBOL QTY
+tl update set SYMBOL QTY
+tl update order buy SYMBOL QTY LIMIT
+tl update order sell SYMBOL QTY LIMIT
+tl update order clear SYMBOL
+tl update order clear-all
+```
+
+Typical morning routine:
+
+```bash
+tlfull
+tl update cash 1000
+tl update account-value 5000
+tl decide --risk-mode balanced
+tl portfolio gui
+```
+
+## CSV Schemas
+
+Create these files only if you want local portfolio-aware decisions. Missing files are allowed and produce an empty local portfolio state.
+
+### `data/raw/portfolio/positions.csv`
+
+Columns:
+
+```text
+symbol,quantity,notes,updated_at
+```
+
+Example:
+
+```csv
+symbol,quantity,notes,updated_at
+TQQQ,4,current_position,2026-05-04
+META,0.040567,current_position,2026-05-04
+```
+
+Do not store prices here. Position values are calculated from the latest local market CSV close/adjusted close.
+
+### `data/raw/portfolio/open_orders.csv`
+
+Columns:
+
+```text
+symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes
+```
+
+Example:
+
+```csv
+symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes
+TQQQ,buy,limit,10,58.00,GTC,placed,2026-04-29,current_open_order
+TQQQ,sell,limit,4,68.50,GTC,placed,2026-04-29,current_open_order
+```
+
+These are manually tracked local orders. They are not read from a broker, and changing them does not place, cancel, or modify broker orders.
+
+### `data/raw/portfolio/account.csv`
+
+Columns:
+
+```text
+key,value,updated_at
+```
+
+Example:
+
+```csv
+key,value,updated_at
+cash,1000,2026-05-04
+account_value,5000,2026-05-04
+```
+
+CLI flags can override saved account values for a single decision run:
+
+```bash
+tl decide --account-value 5000 --cash 1000
+```
+
+## Risk Modes
+
+- `conservative`: exposure-first. If current plus pending exposure exceeds the recommended max, buy orders are likely to be cancel/reduce candidates.
+- `balanced`: exposure plus ladder quality. It keeps exposure warnings, but deep or better-quality ladder orders may be reviewed instead of automatically canceled.
+- `aggressive`: trend/risk-seeking. It can tolerate higher drawdown risk and rank orders by trend and ladder quality, while still showing exposure warnings.
+
+Risk mode changes local advice only. It does not trigger downloads, broker actions, or automated trading.
+
+## GUI
+
+Start the local dashboard:
+
+```bash
+tl portfolio gui
+```
+
+The GUI binds to localhost only and uses existing local files. It can edit `positions.csv`, `open_orders.csv`, and `account.csv` through forms, then reload the dashboard. It does not run the full daily workflow, download market data, train models, generate plots, or connect to any broker.


### PR DESCRIPTION
Documents the daily tl workflow, local portfolio CSV schemas, risk modes, and local-only no-broker behavior. Closes #18.