### PR TITLE
Add trend-aware review for non-traded holdings

### DIFF
--- a/src/trading_lab/cli/main.py
+++ b/src/trading_lab/cli/main.py
@@ -151,11 +151,23 @@ def _portfolio_command(args: argparse.Namespace) -> None:
 
     command = args.portfolio_command or "status"
     if command == "status":
-        print(
-            summarize_portfolio_state(
-                build_portfolio_state(account_value=args.account_value, cash=args.cash)
-            )
-        )
+        state = build_portfolio_state(account_value=args.account_value, cash=args.cash)
+        lines = [summarize_portfolio_state(state)]
+        from trading_lab.config import load_trading_config
+        from trading_lab.portfolio.review import review_holdings
+
+        traded = load_trading_config().traded_symbol
+        reviews = review_holdings(state, traded)
+        if reviews:
+            lines.extend(["", "Non-traded holdings trend review:"])
+            for row in reviews:
+                date_text = f", price date {row.latest_price_date}" if row.latest_price_date else ""
+                lines.append(
+                    f"- {row.symbol}: size {row.status}, trend {row.trend_status}{date_text}. "
+                    f"{row.trend_note}"
+                )
+            lines.append("- No model-backed predictions are claimed for non-traded holdings.")
+        print("\n".join(lines))
         return
     if command == "positions":
         positions = read_positions()

--- a/src/trading_lab/decision.py
+++ b/src/trading_lab/decision.py
@@ -54,6 +54,7 @@ class DecisionInputs:
     selected_signal: dict[str, str]
     portfolio_state: PortfolioState | None = None
     risk_mode: str = "conservative"
+    market_dir: Path = DEFAULT_MARKET_DIR
 
 
 def parse_position(value: str) -> Position:
@@ -179,6 +180,7 @@ def load_decision_inputs(
         selected_signal=selected_signal,
         portfolio_state=local_portfolio,
         risk_mode=resolved_risk_mode,
+        market_dir=market_dir,
     )
 
 
@@ -375,7 +377,7 @@ def _portfolio_holdings_review_lines(inputs: DecisionInputs) -> list[str]:
     state = inputs.portfolio_state
     if state is None:
         return []
-    reviews = review_holdings(state, inputs.traded_symbol)
+    reviews = review_holdings(state, inputs.traded_symbol, market_dir=inputs.market_dir)
     lines = ["Portfolio holdings review:"]
     if not reviews:
         lines.append("- No non-traded holdings to review.")
@@ -383,9 +385,11 @@ def _portfolio_holdings_review_lines(inputs: DecisionInputs) -> list[str]:
     for row in reviews:
         value = _format_money(row.value)
         allocation = _format_pct(row.allocation)
+        date_text = f", price date {row.latest_price_date}" if row.latest_price_date else ""
         lines.append(
             f"- {row.symbol}: qty {row.quantity:g}, value {value}, "
-            f"allocation {allocation}, price {row.price_status}, status {row.status}."
+            f"allocation {allocation}, price {row.price_status}, status {row.status}, "
+            f"trend {row.trend_status}{date_text}. {row.trend_note}"
         )
     lines.append("- No model-backed predictions are claimed for non-traded holdings.")
     return lines

--- a/src/trading_lab/portfolio/gui_render.py
+++ b/src/trading_lab/portfolio/gui_render.py
@@ -250,7 +250,7 @@ def _positions_tab(active_tab: str, state, holding_reviews, traded_symbol: str, 
       <p class="muted">No model-backed buy/sell predictions are claimed for non-traded holdings.</p>
       <div class="table-scroll">
         <table>
-          <tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>Value</th><th>Allocation</th><th>Updated</th><th>Review status</th><th>Review note</th></tr>
+          <tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>Value</th><th>Allocation</th><th>Updated</th><th>Review status</th><th>Review note</th><th>Price date</th><th>Trend status</th><th>Trend note</th></tr>
           {_position_review_rows(state, holding_reviews, traded_symbol)}
         </table>
       </div>
@@ -393,6 +393,9 @@ def _position_review_rows(state, reviews, traded_symbol: str) -> str:
         else:
             status = review.status
             note = f"Price {review.price_status}; no model-backed prediction."
+        trend_status = review.trend_status if review is not None else "REVIEW"
+        trend_note = review.trend_note if review is not None else "No trend review available."
+        latest_price_date = review.latest_price_date if review is not None else ""
         rows.append(
             "<tr>"
             f"<td>{escape(symbol)}</td>"
@@ -403,9 +406,12 @@ def _position_review_rows(state, reviews, traded_symbol: str) -> str:
             f"<td>{escape(updated.get(symbol, ''))}</td>"
             f"<td>{escape(status)}</td>"
             f"<td>{escape(note)}</td>"
+            f"<td>{escape(latest_price_date)}</td>"
+            f"<td>{escape(trend_status)}</td>"
+            f"<td>{escape(trend_note)}</td>"
             "</tr>"
         )
-    return "\n".join(rows) or "<tr><td colspan='8'>No local positions or orders.</td></tr>"
+    return "\n".join(rows) or "<tr><td colspan='11'>No local positions or orders.</td></tr>"
 
 
 def _combined_order_rows(state, reviews) -> str:

--- a/src/trading_lab/portfolio/review.py
+++ b/src/trading_lab/portfolio/review.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import re
+import csv
 from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
 
-from trading_lab.portfolio.state import OpenOrder, PortfolioState, SymbolPortfolioState
+from trading_lab.portfolio.state import MARKET_DIR, OpenOrder, PortfolioState, SymbolPortfolioState
 
 
 @dataclass(frozen=True)
@@ -14,6 +17,15 @@ class HoldingReview:
     allocation: float | None
     price_status: str
     status: str
+    trend_status: str = "REVIEW"
+    trend_note: str = "Trend unavailable; no model-backed trade signal."
+    latest_price_date: str = ""
+    return_5d: float | None = None
+    return_20d: float | None = None
+    distance_20dma: float | None = None
+    distance_50dma: float | None = None
+    drawdown_20d_high: float | None = None
+    drawdown_60d_high: float | None = None
 
 
 @dataclass(frozen=True)
@@ -47,23 +59,40 @@ class ExposureContext:
     buy_capacity: float | None
 
 
+@dataclass(frozen=True)
+class HoldingTrend:
+    status: str
+    latest_date: date | None = None
+    return_5d: float | None = None
+    return_20d: float | None = None
+    distance_20dma: float | None = None
+    distance_50dma: float | None = None
+    drawdown_20d_high: float | None = None
+    drawdown_60d_high: float | None = None
+
+
 def review_holdings(
     state: PortfolioState,
     traded_symbol: str,
     small_threshold: float = 0.02,
     review_size_threshold: float = 0.05,
+    market_dir: Path = MARKET_DIR,
+    reference_date: date | None = None,
 ) -> tuple[HoldingReview, ...]:
     rows: list[HoldingReview] = []
     traded = traded_symbol.upper()
+    resolved_reference_date = reference_date or _reference_market_date(market_dir, traded)
     for symbol in sorted(state.symbols):
         if symbol == traded:
             continue
         item = state.symbols[symbol]
         if item.quantity == 0:
             continue
+        trend = _holding_trend(symbol, market_dir, resolved_reference_date)
         if item.latest_price is None:
             status = "PRICE_MISSING"
             price_status = "missing"
+            trend = HoldingTrend("PRICE_MISSING")
         elif item.allocation_pct is None:
             status = "REVIEW"
             price_status = "known"
@@ -84,6 +113,15 @@ def review_holdings(
                 allocation=item.allocation_pct,
                 price_status=price_status,
                 status=status,
+                trend_status=trend.status,
+                trend_note=_trend_note(item, trend),
+                latest_price_date=trend.latest_date.isoformat() if trend.latest_date else "",
+                return_5d=trend.return_5d,
+                return_20d=trend.return_20d,
+                distance_20dma=trend.distance_20dma,
+                distance_50dma=trend.distance_50dma,
+                drawdown_20d_high=trend.drawdown_20d_high,
+                drawdown_60d_high=trend.drawdown_60d_high,
             )
         )
     return tuple(rows)
@@ -325,6 +363,152 @@ def normalize_risk_mode(value: str | None) -> str:
     if mode not in {"conservative", "balanced", "aggressive"}:
         raise ValueError("risk mode must be conservative, balanced, or aggressive")
     return mode
+
+
+def _reference_market_date(market_dir: Path, traded_symbol: str) -> date | None:
+    traded_date = _latest_market_row(traded_symbol, market_dir)[0]
+    if traded_date is not None:
+        return traded_date
+    return None
+
+
+def _holding_trend(
+    symbol: str,
+    market_dir: Path,
+    reference_date: date | None,
+) -> HoldingTrend:
+    reference_date = reference_date or date.today()
+    latest_date, prices = _latest_market_row(symbol, market_dir)
+    if latest_date is None or not prices:
+        return HoldingTrend("PRICE_MISSING")
+    if reference_date is not None and latest_date < reference_date:
+        return HoldingTrend("PRICE_STALE", latest_date=latest_date)
+
+    latest = prices[-1]
+    return_5d = _return_since(prices, 5)
+    return_20d = _return_since(prices, 20)
+    dma20 = _mean(prices[-20:]) if len(prices) >= 20 else None
+    dma50 = _mean(prices[-50:]) if len(prices) >= 50 else None
+    distance_20dma = (latest / dma20 - 1.0) if dma20 else None
+    distance_50dma = (latest / dma50 - 1.0) if dma50 else None
+    high20 = max(prices[-20:]) if len(prices) >= 20 else None
+    high60 = max(prices[-60:]) if len(prices) >= 60 else None
+    drawdown_20d_high = (latest / high20 - 1.0) if high20 else None
+    drawdown_60d_high = (latest / high60 - 1.0) if high60 else None
+
+    above20 = distance_20dma is not None and distance_20dma >= 0
+    above50 = distance_50dma is not None and distance_50dma >= 0
+    positive20 = return_20d is not None and return_20d > 0
+    negative20 = return_20d is not None and return_20d < 0
+    pullback = (
+        drawdown_20d_high is not None
+        and drawdown_20d_high <= -0.05
+        and (above50 or positive20)
+        and not (distance_20dma is not None and distance_20dma < -0.03 and not above50)
+    )
+
+    if pullback:
+        status = "PULLBACK"
+    elif above20 and above50 and positive20:
+        status = "STRONG_UPTREND"
+    elif above20 or positive20:
+        status = "UPTREND"
+    elif (
+        distance_20dma is not None
+        and distance_20dma < 0
+        and distance_50dma is not None
+        and distance_50dma < 0
+        and negative20
+    ):
+        status = "DOWNTREND"
+    else:
+        status = "REVIEW"
+    return HoldingTrend(
+        status,
+        latest_date=latest_date,
+        return_5d=return_5d,
+        return_20d=return_20d,
+        distance_20dma=distance_20dma,
+        distance_50dma=distance_50dma,
+        drawdown_20d_high=drawdown_20d_high,
+        drawdown_60d_high=drawdown_60d_high,
+    )
+
+
+def _latest_market_row(symbol: str, market_dir: Path) -> tuple[date | None, list[float]]:
+    path = market_dir / f"{symbol.upper()}.csv"
+    if not path.exists():
+        return None, []
+    rows: list[tuple[date, float]] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            parsed_date = _parse_date(row.get("date", ""))
+            price = _row_price(row)
+            if parsed_date is not None and price is not None:
+                rows.append((parsed_date, price))
+    if not rows:
+        return None, []
+    rows.sort(key=lambda item: item[0])
+    return rows[-1][0], [price for _, price in rows]
+
+
+def _row_price(row: dict[str, str]) -> float | None:
+    normalized = {key.strip().lower().replace(" ", "_").replace("-", "_"): key for key in row}
+    for candidate in ("adj_close", "adjusted_close", "close"):
+        column = normalized.get(candidate)
+        if column and row.get(column, "").strip():
+            try:
+                return float(row[column].replace("$", "").replace(",", "").strip())
+            except ValueError:
+                return None
+    return None
+
+
+def _parse_date(value: str) -> date | None:
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        try:
+            return datetime.strptime(text[:10], "%m/%d/%Y").date()
+        except ValueError:
+            return None
+
+
+def _return_since(values: list[float], periods: int) -> float | None:
+    if len(values) <= periods:
+        return None
+    base = values[-periods - 1]
+    if base == 0:
+        return None
+    return values[-1] / base - 1.0
+
+
+def _mean(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _trend_note(item: SymbolPortfolioState, trend: HoldingTrend) -> str:
+    prefix = "Tiny holding; " if item.allocation_pct is not None and item.allocation_pct < 0.02 else ""
+    if trend.status == "PRICE_MISSING":
+        return "Price data missing; run tlfull or market update."
+    if trend.status == "PRICE_STALE":
+        return "Price data stale; refresh before using this."
+    if trend.status == "STRONG_UPTREND":
+        return f"{prefix}uptrend intact, no model-backed trade signal."
+    if trend.status == "UPTREND":
+        return f"{prefix}trend is constructive, no model-backed trade signal."
+    if trend.status == "PULLBACK":
+        return f"{prefix}pullback from recent high; no model-backed trade signal."
+    if trend.status == "DOWNTREND":
+        return (
+            f"{prefix}price below 20DMA and 50DMA, review if this is intentional; "
+            "no model-backed trade signal."
+        )
+    return f"{prefix}mixed trend; review manually, no model-backed trade signal."
 
 
 def _review_other_symbol_order(

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -174,6 +174,47 @@ def test_decision_risk_mode_aggressive_keeps_deep_buy_under_review(tmp_path):
     assert "REVIEW TQQQ buy 1 @ $52.00" in text
 
 
+def test_decision_includes_trend_review_for_non_traded_holdings(tmp_path):
+    reports = _write_reports(tmp_path)
+    portfolio_dir = tmp_path / "data" / "raw" / "portfolio"
+    market_dir = tmp_path / "data" / "raw" / "market"
+    portfolio_dir.mkdir(parents=True)
+    market_dir.mkdir(parents=True)
+    (portfolio_dir / "positions.csv").write_text(
+        "symbol,quantity,notes,updated_at\n"
+        "TQQQ,4,current_position,2026-05-04\n"
+        "META,1,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+    (portfolio_dir / "open_orders.csv").write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n",
+        encoding="utf-8",
+    )
+    meta_prices = "\n".join(
+        ["date,close"]
+        + [
+            f"2026-04-{i + 1:02d},{50 + i:.2f}" if i < 30 else f"2026-05-{i - 29:02d},{50 + i:.2f}"
+            for i in range(60)
+        ]
+    )
+    tqqq_prices = "\n".join(
+        ["date,close"]
+        + [
+            f"2026-04-{i + 1:02d},60.00" if i < 30 else f"2026-05-{i - 29:02d},60.00"
+            for i in range(60)
+        ]
+    )
+    (market_dir / "META.csv").write_text(meta_prices + "\n", encoding="utf-8")
+    (market_dir / "TQQQ.csv").write_text(tqqq_prices + "\n", encoding="utf-8")
+
+    text = render_daily_decision(reports_dir=reports, account_value=5000)
+
+    assert "META: qty 1" in text
+    assert "trend STRONG_UPTREND" in text
+    assert "uptrend intact, no model-backed trade signal" in text
+    assert "No model-backed predictions are claimed for non-traded holdings." in text
+
+
 def test_decision_missing_portfolio_files_do_not_break_decide(tmp_path):
     reports = _write_reports(tmp_path)
 

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -160,8 +160,12 @@ def test_gui_combines_positions_with_holdings_review(tmp_path, monkeypatch):
     assert "META" in html
     assert "Review status" in html
     assert "Review note" in html
+    assert "Price date" in html
+    assert "Trend status" in html
+    assert "Trend note" in html
     assert "OK_SMALL" in html
     assert "PRICE_MISSING" in html
+    assert "no model-backed trade signal" in html
     assert "Portfolio holdings review" not in html
     assert "No model-backed buy/sell predictions are claimed" in html
 

--- a/tests/test_portfolio_review.py
+++ b/tests/test_portfolio_review.py
@@ -1,7 +1,33 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from trading_lab.portfolio.review import review_holdings, review_open_orders
 from trading_lab.portfolio.state import OpenOrder, PortfolioState, SymbolPortfolioState
+
+
+def _write_market(path: Path, symbol: str, prices: list[float], start_day: int = 1) -> None:
+    rows = ["date,close"]
+    for index, price in enumerate(prices, start=start_day):
+        rows.append(f"2026-04-{index:02d},{price:.2f}" if index <= 30 else f"2026-05-{index - 30:02d},{price:.2f}")
+    (path / f"{symbol}.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def _state_for(symbol: str, price: float = 100.0) -> PortfolioState:
+    return PortfolioState(
+        symbols={
+            "TQQQ": SymbolPortfolioState(symbol="TQQQ", quantity=4, latest_price=60),
+            symbol: SymbolPortfolioState(
+                symbol=symbol,
+                quantity=1,
+                latest_price=price,
+                market_value=price,
+                allocation_pct=0.01,
+            ),
+        }
+    )
 
 
 def test_non_traded_holdings_review_statuses():
@@ -31,6 +57,65 @@ def test_non_traded_holdings_review_statuses():
     assert reviews["META"].status == "OK_SMALL"
     assert reviews["BIG"].status == "REVIEW_SIZE"
     assert reviews["MISS"].status == "PRICE_MISSING"
+
+
+def test_non_traded_holding_strong_uptrend_from_local_market_csv(tmp_path: Path):
+    _write_market(tmp_path, "TQQQ", [60 + i for i in range(60)])
+    _write_market(tmp_path, "META", [50 + i for i in range(60)])
+
+    review = review_holdings(_state_for("META", 109), "TQQQ", market_dir=tmp_path)[0]
+
+    assert review.trend_status == "STRONG_UPTREND"
+    assert review.return_20d is not None and review.return_20d > 0
+    assert review.distance_20dma is not None and review.distance_20dma > 0
+    assert "no model-backed trade signal" in review.trend_note
+
+
+def test_non_traded_holding_downtrend_from_local_market_csv(tmp_path: Path):
+    _write_market(tmp_path, "TQQQ", [60 + i for i in range(60)])
+    _write_market(tmp_path, "META", [120 - i for i in range(60)])
+
+    review = review_holdings(_state_for("META", 61), "TQQQ", market_dir=tmp_path)[0]
+
+    assert review.trend_status == "DOWNTREND"
+    assert "below 20DMA and 50DMA" in review.trend_note
+
+
+def test_non_traded_holding_pullback_from_local_market_csv(tmp_path: Path):
+    _write_market(tmp_path, "TQQQ", [60 + i for i in range(60)])
+    pullback = list(range(45, 85)) + list(range(85, 101)) + [94, 94, 94, 94]
+    _write_market(tmp_path, "META", [float(value) for value in pullback])
+
+    review = review_holdings(_state_for("META", 94), "TQQQ", market_dir=tmp_path)[0]
+
+    assert review.trend_status == "PULLBACK"
+    assert review.drawdown_20d_high == pytest.approx(-0.06)
+    assert "pullback from recent high" in review.trend_note
+
+
+def test_non_traded_holding_missing_and_stale_price_statuses(tmp_path: Path):
+    _write_market(tmp_path, "TQQQ", [60 + i for i in range(60)])
+    _write_market(tmp_path, "OLD", [50 + i for i in range(57)])
+    state = PortfolioState(
+        symbols={
+            "TQQQ": SymbolPortfolioState(symbol="TQQQ", quantity=4, latest_price=60),
+            "MISS": SymbolPortfolioState(symbol="MISS", quantity=1),
+            "OLD": SymbolPortfolioState(
+                symbol="OLD",
+                quantity=1,
+                latest_price=106,
+                market_value=106,
+                allocation_pct=0.01,
+            ),
+        }
+    )
+
+    reviews = {row.symbol: row for row in review_holdings(state, "TQQQ", market_dir=tmp_path)}
+
+    assert reviews["MISS"].trend_status == "PRICE_MISSING"
+    assert "Price data missing" in reviews["MISS"].trend_note
+    assert reviews["OLD"].trend_status == "PRICE_STALE"
+    assert "Price data stale" in reviews["OLD"].trend_note
 
 
 def test_order_review_marks_over_capacity_buys_cancel_or_reduce_and_sell_not_aggressive():

--- a/tests/test_portfolio_state.py
+++ b/tests/test_portfolio_state.py
@@ -245,3 +245,34 @@ def test_cli_update_commands_modify_local_csvs(tmp_path: Path, monkeypatch, caps
     assert read_account(ACCOUNT_PATH).account_value == 5000
     assert all(order.status == "canceled" for order in read_open_orders(OPEN_ORDERS_PATH))
     assert "Local-only update" in capsys.readouterr().out
+
+
+def test_cli_portfolio_status_includes_non_traded_trend_review(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    portfolio_dir = tmp_path / "data" / "raw" / "portfolio"
+    market_dir = tmp_path / "data" / "raw" / "market"
+    portfolio_dir.mkdir(parents=True)
+    market_dir.mkdir(parents=True)
+    (portfolio_dir / "positions.csv").write_text(
+        "symbol,quantity,notes,updated_at\n"
+        "TQQQ,4,current_position,2026-05-04\n"
+        "META,1,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+    (portfolio_dir / "open_orders.csv").write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n",
+        encoding="utf-8",
+    )
+    rows = ["date,close"] + [f"2026-05-{day:02d},{100 + day:.2f}" for day in range(1, 22)]
+    (market_dir / "TQQQ.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    (market_dir / "META.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    import trading_lab.cli.main as cli_main
+
+    monkeypatch.setattr("sys.argv", ["tl", "portfolio", "status", "--account-value", "5000"])
+    cli_main.main()
+
+    out = capsys.readouterr().out
+    assert "Non-traded holdings trend review:" in out
+    assert "META: size REVIEW, trend" in out
+    assert "No model-backed predictions are claimed for non-traded holdings." in out


### PR DESCRIPTION
Adds non-model-backed trend/status review for portfolio holdings using local market CSVs while preserving local-only behavior. Closes #21.