### PR TITLE
Track outcomes for portfolio decisions

### DIFF
--- a/docs/local_portfolio.md
+++ b/docs/local_portfolio.md
@@ -36,6 +36,10 @@ Record local snapshots for later outcome analysis:
 tl portfolio snapshot --risk-mode balanced --notes "morning review"
 tl portfolio snapshots
 tl decide --risk-mode balanced --snapshot --snapshot-notes "after review"
+tl portfolio outcome-record --risk-mode balanced --notes "track decision"
+tl portfolio outcome-update
+tl portfolio outcomes
+tl decide --risk-mode balanced --record-outcome --outcome-notes "track decision"
 ```
 
 Local portfolio updates:
@@ -60,6 +64,7 @@ tl update cash 1000
 tl update account-value 5000
 tl decide --risk-mode balanced
 tl portfolio snapshot --risk-mode balanced --notes "morning review"
+tl portfolio outcome-record --risk-mode balanced --notes "morning review"
 tl portfolio gui
 ```
 
@@ -155,6 +160,50 @@ tl portfolio snapshots --limit 10
 ```bash
 tl decide --risk-mode balanced --snapshot --snapshot-notes "decision recorded"
 ```
+
+## Outcome Tracking
+
+Decision outcome tracking is optional local history for evaluating whether daily decisions and suggested order ideas were useful. It appends rows to:
+
+```text
+data/processed/portfolio/decision_outcomes.csv
+```
+
+That file is under gitignored `data/` and should stay private/local. Outcome commands only read existing reports, local portfolio CSVs, and local market CSVs. They do not run `tlfull`, download prices, train models, run backtests, generate plots, connect to a broker, or place/cancel orders.
+
+Record the current decision state:
+
+```bash
+tl portfolio outcome-record --risk-mode balanced --notes "morning decision"
+```
+
+Update previously recorded rows after enough local future market data exists:
+
+```bash
+tl portfolio outcome-update
+```
+
+View recent rows:
+
+```bash
+tl portfolio outcomes --limit 10
+```
+
+Optional aliases are also available:
+
+```bash
+tl outcome record --risk-mode balanced --notes "morning decision"
+tl outcome update
+tl outcome list
+```
+
+`tl decide` does not record outcomes by default, but you can opt in for a single run:
+
+```bash
+tl decide --risk-mode balanced --record-outcome --outcome-notes "decision tracked"
+```
+
+Future outcome fields are filled only from local market CSVs when enough later rows exist. Until then, rows remain `PENDING` or `INSUFFICIENT_FUTURE_DATA`; missing local price data is marked `PRICE_MISSING`.
 
 ## GUI
 

--- a/src/trading_lab/cli/main.py
+++ b/src/trading_lab/cli/main.py
@@ -32,6 +32,8 @@ def main() -> None:
     )
     decide.add_argument("--snapshot", action="store_true")
     decide.add_argument("--snapshot-notes", default="")
+    decide.add_argument("--record-outcome", action="store_true")
+    decide.add_argument("--outcome-notes", default="")
 
     portfolio = sub.add_parser("portfolio")
     portfolio_sub = portfolio.add_subparsers(dest="portfolio_command")
@@ -50,6 +52,16 @@ def main() -> None:
     portfolio_snapshot.add_argument("--notes", default="")
     portfolio_snapshots = portfolio_sub.add_parser("snapshots")
     portfolio_snapshots.add_argument("--limit", type=int, default=10)
+    portfolio_outcome_record = portfolio_sub.add_parser("outcome-record")
+    portfolio_outcome_record.add_argument(
+        "--risk-mode",
+        choices=["conservative", "balanced", "aggressive"],
+        default="conservative",
+    )
+    portfolio_outcome_record.add_argument("--notes", default="")
+    portfolio_sub.add_parser("outcome-update")
+    portfolio_outcomes = portfolio_sub.add_parser("outcomes")
+    portfolio_outcomes.add_argument("--limit", type=int, default=10)
     portfolio_set = portfolio_sub.add_parser("set")
     portfolio_set.add_argument("symbol")
     portfolio_set.add_argument("quantity", type=float)
@@ -84,6 +96,19 @@ def main() -> None:
     update_order_clear.add_argument("symbol")
     update_order_sub.add_parser("clear-all")
 
+    outcome = sub.add_parser("outcome")
+    outcome_sub = outcome.add_subparsers(dest="outcome_command")
+    outcome_record = outcome_sub.add_parser("record")
+    outcome_record.add_argument(
+        "--risk-mode",
+        choices=["conservative", "balanced", "aggressive"],
+        default="conservative",
+    )
+    outcome_record.add_argument("--notes", default="")
+    outcome_list = outcome_sub.add_parser("list")
+    outcome_list.add_argument("--limit", type=int, default=10)
+    outcome_sub.add_parser("update")
+
     args, rest = parser.parse_known_args()
     command = args.command or "status"
 
@@ -110,18 +135,35 @@ def main() -> None:
             risk_mode=args.risk_mode,
         )
         print(text)
-        if not args.snapshot:
-            print("\nRun tl portfolio snapshot to record this state.")
-            return
-        from trading_lab.portfolio.snapshots import append_snapshot
+        wrote_extra = False
+        if args.snapshot:
+            from trading_lab.portfolio.snapshots import append_snapshot
 
-        result = append_snapshot(
-            risk_mode=args.risk_mode,
-            notes=args.snapshot_notes,
-            account_value=args.account_value,
-            cash=args.cash,
-        )
-        print(f"\nRecorded local-only portfolio snapshot at {result.path}.")
+            result = append_snapshot(
+                risk_mode=args.risk_mode,
+                notes=args.snapshot_notes,
+                account_value=args.account_value,
+                cash=args.cash,
+            )
+            print(f"\nRecorded local-only portfolio snapshot at {result.path}.")
+            wrote_extra = True
+        if args.record_outcome:
+            from trading_lab.portfolio.outcomes import append_outcome
+
+            result = append_outcome(
+                risk_mode=args.risk_mode,
+                notes=args.outcome_notes,
+                account_value=args.account_value,
+                cash=args.cash,
+            )
+            print(f"\nRecorded local-only decision outcome row at {result.path}.")
+            wrote_extra = True
+        if not wrote_extra:
+            print(
+                "\nRun tl portfolio snapshot to record this state.\n"
+                "Run tl portfolio outcome-record to track this decision outcome."
+            )
+            return
         return
 
     if command == "portfolio":
@@ -130,6 +172,10 @@ def main() -> None:
 
     if command == "update":
         _update_command(args)
+        return
+
+    if command == "outcome":
+        _outcome_command(args)
         return
 
     if command == "plots":
@@ -229,6 +275,23 @@ def _portfolio_command(args: argparse.Namespace) -> None:
 
         print(format_snapshots(read_snapshots(limit=args.limit)))
         return
+    if command == "outcome-record":
+        from trading_lab.portfolio.outcomes import append_outcome
+
+        result = append_outcome(risk_mode=args.risk_mode, notes=args.notes)
+        print(f"Recorded local-only decision outcome row at {result.path}.")
+        return
+    if command == "outcome-update":
+        from trading_lab.portfolio.outcomes import OUTCOMES_PATH, update_outcomes
+
+        updated = update_outcomes()
+        print(f"Updated {updated} local decision outcome row(s) in {OUTCOMES_PATH}.")
+        return
+    if command == "outcomes":
+        from trading_lab.portfolio.outcomes import format_outcomes, read_outcomes
+
+        print(format_outcomes(read_outcomes(limit=args.limit)))
+        return
     if command == "set":
         write_position(POSITIONS_PATH, args.symbol, args.quantity)
         print(f"Updated local position for {args.symbol.upper()} in {POSITIONS_PATH}.")
@@ -251,6 +314,28 @@ def _portfolio_command(args: argparse.Namespace) -> None:
         )
         return
     raise SystemExit(f"Unknown portfolio command: {command}")
+
+
+def _outcome_command(args: argparse.Namespace) -> None:
+    command = args.outcome_command or "list"
+    if command == "record":
+        from trading_lab.portfolio.outcomes import append_outcome
+
+        result = append_outcome(risk_mode=args.risk_mode, notes=args.notes)
+        print(f"Recorded local-only decision outcome row at {result.path}.")
+        return
+    if command == "list":
+        from trading_lab.portfolio.outcomes import format_outcomes, read_outcomes
+
+        print(format_outcomes(read_outcomes(limit=args.limit)))
+        return
+    if command == "update":
+        from trading_lab.portfolio.outcomes import OUTCOMES_PATH, update_outcomes
+
+        updated = update_outcomes()
+        print(f"Updated {updated} local decision outcome row(s) in {OUTCOMES_PATH}.")
+        return
+    raise SystemExit("Usage: tl outcome {record,list,update} ...")
 
 
 def _update_command(args: argparse.Namespace) -> None:

--- a/src/trading_lab/portfolio/gui_forms.py
+++ b/src/trading_lab/portfolio/gui_forms.py
@@ -54,6 +54,19 @@ def apply_form_action(path: str, fields: dict[str, str]) -> str:
             notes=fields.get("notes", "").strip(),
         )
         return "recorded local snapshot"
+    if path == "/outcome/record":
+        from trading_lab.portfolio.outcomes import append_outcome
+
+        append_outcome(
+            risk_mode=fields.get("risk_mode", "conservative"),
+            notes=fields.get("notes", "").strip(),
+        )
+        return "recorded local outcome"
+    if path == "/outcome/update":
+        from trading_lab.portfolio.outcomes import update_outcomes
+
+        update_outcomes()
+        return "updated local outcomes"
     raise ValueError(f"Unknown form action: {path}")
 
 

--- a/src/trading_lab/portfolio/gui_render.py
+++ b/src/trading_lab/portfolio/gui_render.py
@@ -13,6 +13,7 @@ from trading_lab.decision import (
 )
 from trading_lab.portfolio.gui_assets import CSS, dashboard_script
 from trading_lab.portfolio.gui_forms import render_forms
+from trading_lab.portfolio.outcomes import read_outcomes
 from trading_lab.portfolio.snapshots import read_snapshots
 from trading_lab.portfolio.state import (
     ACCOUNT_PATH,
@@ -105,6 +106,7 @@ def render_status_page(risk_mode: str = "conservative", active_tab: str = "daily
         order_summary,
         advice,
         _snapshot_card(risk_mode),
+        _outcome_card(risk_mode),
     )
     positions_tab = _positions_tab(
         active_tab,
@@ -183,6 +185,7 @@ def _daily_tab(
     order_summary,
     advice,
     snapshot_card: str,
+    outcome_card: str,
 ) -> str:
     return f"""
   <section class="{_tab_panel_class("daily", active_tab)}" id="tab-daily">
@@ -243,6 +246,7 @@ def _daily_tab(
       </section>
     </div>
     {snapshot_card}
+    {outcome_card}
   </section>"""
 
 
@@ -337,6 +341,48 @@ def _snapshot_rows(rows: list[dict[str, str]]) -> str:
             f"<td>{escape(row.get('traded_symbol', ''))}</td>"
             f"<td>{_money(_float_or_none(row.get('traded_value')))}</td>"
             f"<td>{escape(row.get('notes', ''))}</td>"
+            "</tr>"
+        )
+    return "\n".join(out)
+
+
+def _outcome_card(risk_mode: str) -> str:
+    return f"""
+    <section class="card">
+      <h2>Decision outcomes</h2>
+      <p class="muted">Local outcome tracking only. This rereads existing CSVs and never runs daily or contacts a broker.</p>
+      <form method="post" action="/outcome/record">
+        <input type="hidden" name="risk_mode" value="{escape(risk_mode)}">
+        <label class="span-2">Notes <input name="notes"></label>
+        <button type="submit">Record outcome</button>
+      </form>
+      <form method="post" action="/outcome/update">
+        <button type="submit">Update outcomes</button>
+      </form>
+      <h3>Recent outcomes</h3>
+      <div class="table-scroll mini-scroll">
+        <table>
+          <tr><th>Timestamp</th><th>Mode</th><th>Action</th><th>Symbol</th><th>Price</th><th>5d return</th><th>Status</th></tr>
+          {_outcome_rows(read_outcomes(limit=5))}
+        </table>
+      </div>
+    </section>"""
+
+
+def _outcome_rows(rows: list[dict[str, str]]) -> str:
+    if not rows:
+        return "<tr><td colspan='7'>No local outcomes recorded.</td></tr>"
+    out = []
+    for row in reversed(rows):
+        out.append(
+            "<tr>"
+            f"<td>{escape(row.get('decision_timestamp', ''))}</td>"
+            f"<td>{escape(row.get('risk_mode', ''))}</td>"
+            f"<td>{escape(row.get('action', ''))}</td>"
+            f"<td>{escape(row.get('traded_symbol', ''))}</td>"
+            f"<td>{_money(_float_or_none(row.get('traded_price_at_decision')))}</td>"
+            f"<td>{_percent_text(row.get('return_5d', ''))}</td>"
+            f"<td>{escape(row.get('outcome_status', ''))}</td>"
             "</tr>"
         )
     return "\n".join(out)
@@ -610,3 +656,8 @@ def _allocation(value: float | None) -> str:
     if value is None:
         return "unknown"
     return f"{value:.1%}"
+
+
+def _percent_text(value: str) -> str:
+    parsed = _float_or_none(value)
+    return "" if parsed is None else f"{parsed:.1%}"

--- a/src/trading_lab/portfolio/outcomes.py
+++ b/src/trading_lab/portfolio/outcomes.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+from trading_lab.config import load_trading_config
+from trading_lab.decision import (
+    DEFAULT_REPORTS_DIR,
+    format_decision,
+    load_decision_inputs,
+)
+from trading_lab.portfolio.review import (
+    exposure_context,
+    normalize_risk_mode,
+    review_open_orders,
+    suggested_order_ideas,
+    summarize_order_reviews,
+)
+from trading_lab.portfolio.state import (
+    ACCOUNT_PATH,
+    MARKET_DIR,
+    OPEN_ORDERS_PATH,
+    POSITIONS_PATH,
+    build_portfolio_state,
+)
+
+
+OUTCOMES_PATH = Path("data/processed/portfolio/decision_outcomes.csv")
+
+OUTCOME_COLUMNS = (
+    "decision_id",
+    "decision_timestamp",
+    "risk_mode",
+    "action",
+    "traded_symbol",
+    "traded_price_at_decision",
+    "model_probability",
+    "active_target_mode",
+    "active_target_column",
+    "suggested_report_action",
+    "strategy_eligible_today",
+    "max_exposure",
+    "current_exposure",
+    "pending_buy_notional",
+    "pending_sell_notional",
+    "suggested_order_summary",
+    "current_price",
+    "future_price_1d",
+    "future_price_3d",
+    "future_price_5d",
+    "future_price_10d",
+    "return_1d",
+    "return_3d",
+    "return_5d",
+    "return_10d",
+    "outcome_status",
+    "notes",
+)
+
+HORIZONS = (1, 3, 5, 10)
+
+
+@dataclass(frozen=True)
+class OutcomeResult:
+    path: Path
+    row: dict[str, str]
+
+
+def build_outcome_row(
+    *,
+    risk_mode: str = "conservative",
+    notes: str = "",
+    reports_dir: Path = DEFAULT_REPORTS_DIR,
+    positions_path: Path = POSITIONS_PATH,
+    open_orders_path: Path = OPEN_ORDERS_PATH,
+    account_path: Path = ACCOUNT_PATH,
+    market_dir: Path = MARKET_DIR,
+    account_value: float | None = None,
+    cash: float | None = None,
+    now: datetime | None = None,
+) -> dict[str, str]:
+    mode = normalize_risk_mode(risk_mode)
+    timestamp = (now or datetime.now()).isoformat(timespec="seconds")
+    config = load_trading_config()
+    state = build_portfolio_state(
+        positions_path=positions_path,
+        open_orders_path=open_orders_path,
+        account_path=account_path,
+        market_dir=market_dir,
+        account_value=account_value,
+        cash=cash,
+    )
+    inputs = load_decision_inputs(
+        reports_dir=reports_dir,
+        positions_path=positions_path,
+        open_orders_path=open_orders_path,
+        account_path=account_path,
+        market_dir=market_dir,
+        risk_mode=mode,
+        account_value=account_value,
+        cash=cash,
+    )
+
+    traded_symbol = (inputs.traded_symbol if inputs is not None else config.traded_symbol).upper()
+    item = state.symbols.get(traded_symbol)
+    summary = inputs.summary if inputs is not None else {}
+    selected_signal = inputs.selected_signal if inputs is not None else {}
+    action = _decision_action(inputs)
+    max_allocation = _percent(summary.get("max_traded_allocation"))
+    decision_price = _float_or_none(summary.get("traded_price"))
+    current_price = decision_price if decision_price is not None else (
+        item.latest_price if item is not None else None
+    )
+    max_exposure = (
+        float(inputs.account_value) * max_allocation
+        if inputs is not None and max_allocation is not None
+        else None
+    )
+    current_exposure = (
+        item.quantity * current_price
+        if item is not None and current_price is not None
+        else item.market_value if item is not None else None
+    )
+    placed_buys = [
+        order
+        for order in state.open_orders
+        if order.status == "placed" and order.side == "buy"
+    ]
+    placed_sells = [
+        order
+        for order in state.open_orders
+        if order.status == "placed" and order.side == "sell"
+    ]
+    order_summary_text = ""
+    if inputs is not None:
+        reviews = review_open_orders(
+            state,
+            traded_symbol,
+            account_value=inputs.account_value,
+            max_allocation=max_allocation,
+            suggested_action=summary.get("suggested_action", "NO_TRADE"),
+            strategy_eligible=summary.get("strategy_eligible", "").upper() == "YES",
+            ladder=inputs.ladder,
+            risk_mode=mode,
+        )
+        review_summary = summarize_order_reviews(reviews)
+        context = exposure_context(state, traded_symbol, inputs.account_value, max_allocation)
+        ideas = suggested_order_ideas(
+            state,
+            traded_symbol,
+            context=context,
+            reviews=reviews,
+            ladder=inputs.ladder,
+            risk_mode=mode,
+        )
+        top = [
+            f"{row.recommended_action} {row.side} {row.symbol} {row.quantity:g} @ {row.limit_price:g}"
+            for row in review_summary.top_actions
+        ]
+        order_summary_text = " | ".join(tuple(ideas) + tuple(top))
+
+    return {
+        "decision_id": timestamp,
+        "decision_timestamp": timestamp,
+        "risk_mode": mode,
+        "action": action,
+        "traded_symbol": traded_symbol,
+        "traded_price_at_decision": _number(current_price),
+        "model_probability": selected_signal.get("probability", ""),
+        "active_target_mode": summary.get("active_target_mode", ""),
+        "active_target_column": summary.get("active_target_column", ""),
+        "suggested_report_action": summary.get("suggested_action", ""),
+        "strategy_eligible_today": summary.get("strategy_eligible", ""),
+        "max_exposure": _number(max_exposure),
+        "current_exposure": _number(current_exposure),
+        "pending_buy_notional": _number(sum(order.exposure for order in placed_buys)),
+        "pending_sell_notional": _number(sum(order.exposure for order in placed_sells)),
+        "suggested_order_summary": order_summary_text,
+        "current_price": _number(current_price),
+        "future_price_1d": "",
+        "future_price_3d": "",
+        "future_price_5d": "",
+        "future_price_10d": "",
+        "return_1d": "",
+        "return_3d": "",
+        "return_5d": "",
+        "return_10d": "",
+        "outcome_status": "PENDING" if current_price is not None else "PRICE_MISSING",
+        "notes": notes,
+    }
+
+
+def append_outcome(
+    *,
+    path: Path = OUTCOMES_PATH,
+    risk_mode: str = "conservative",
+    notes: str = "",
+    reports_dir: Path = DEFAULT_REPORTS_DIR,
+    positions_path: Path = POSITIONS_PATH,
+    open_orders_path: Path = OPEN_ORDERS_PATH,
+    account_path: Path = ACCOUNT_PATH,
+    market_dir: Path = MARKET_DIR,
+    account_value: float | None = None,
+    cash: float | None = None,
+    now: datetime | None = None,
+) -> OutcomeResult:
+    row = build_outcome_row(
+        risk_mode=risk_mode,
+        notes=notes,
+        reports_dir=reports_dir,
+        positions_path=positions_path,
+        open_orders_path=open_orders_path,
+        account_path=account_path,
+        market_dir=market_dir,
+        account_value=account_value,
+        cash=cash,
+        now=now,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    write_header = not path.exists() or path.stat().st_size == 0
+    with path.open("a", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(OUTCOME_COLUMNS), extrasaction="ignore")
+        if write_header:
+            writer.writeheader()
+        writer.writerow(row)
+    return OutcomeResult(path=path, row=row)
+
+
+def read_outcomes(path: Path = OUTCOMES_PATH, limit: int = 10) -> list[dict[str, str]]:
+    if not path.exists() or limit <= 0:
+        return []
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = [
+            {key: value for key, value in row.items() if key is not None}
+            for row in csv.DictReader(handle)
+        ]
+    return rows[-limit:]
+
+
+def update_outcomes(
+    *,
+    path: Path = OUTCOMES_PATH,
+    market_dir: Path = MARKET_DIR,
+) -> int:
+    if not path.exists():
+        return 0
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = [
+            {key: value for key, value in row.items() if key is not None}
+            for row in csv.DictReader(handle)
+        ]
+    updated = 0
+    output: list[dict[str, str]] = []
+    for row in rows:
+        new_row, changed = update_outcome_row(row, market_dir=market_dir)
+        output.append(new_row)
+        if changed:
+            updated += 1
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(OUTCOME_COLUMNS), extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(output)
+    return updated
+
+
+def update_outcome_row(
+    row: dict[str, str],
+    *,
+    market_dir: Path = MARKET_DIR,
+) -> tuple[dict[str, str], bool]:
+    out = {column: row.get(column, "") for column in OUTCOME_COLUMNS}
+    symbol = out.get("traded_symbol", "").upper()
+    decision_date = _date_from_timestamp(out.get("decision_timestamp", ""))
+    prices = _market_prices(symbol, market_dir)
+    if not symbol or decision_date is None or not prices:
+        changed = out.get("outcome_status") != "PRICE_MISSING"
+        out["outcome_status"] = "PRICE_MISSING"
+        return out, changed
+
+    future = [(row_date, price) for row_date, price in prices if row_date > decision_date]
+    base = _float_or_none(out.get("traded_price_at_decision")) or _price_on_or_before(
+        prices,
+        decision_date,
+    )
+    if base is not None and not out.get("current_price"):
+        out["current_price"] = _number(base)
+    if base is not None and not out.get("traded_price_at_decision"):
+        out["traded_price_at_decision"] = _number(base)
+
+    original = dict(out)
+    for horizon in HORIZONS:
+        price_key = f"future_price_{horizon}d"
+        return_key = f"return_{horizon}d"
+        if len(future) >= horizon:
+            future_price = future[horizon - 1][1]
+            out[price_key] = _number(future_price)
+            out[return_key] = _number(future_price / base - 1.0) if base else ""
+        else:
+            out.setdefault(price_key, "")
+            out.setdefault(return_key, "")
+
+    if all(out.get(f"future_price_{horizon}d") for horizon in HORIZONS):
+        out["outcome_status"] = "UPDATED"
+    elif any(out.get(f"future_price_{horizon}d") for horizon in HORIZONS):
+        out["outcome_status"] = "INSUFFICIENT_FUTURE_DATA"
+    else:
+        out["outcome_status"] = "PENDING" if future else "INSUFFICIENT_FUTURE_DATA"
+    return out, out != original
+
+
+def format_outcomes(rows: list[dict[str, str]]) -> str:
+    if not rows:
+        return "No local decision outcomes found."
+    lines = ["Recent decision outcomes:"]
+    for row in rows:
+        bits = [
+            row.get("decision_timestamp", ""),
+            row.get("risk_mode", ""),
+            row.get("action", ""),
+            row.get("traded_symbol", ""),
+            _money_text(row.get("traded_price_at_decision", "")),
+            row.get("outcome_status", ""),
+            _percent_text(row.get("return_5d", "")),
+        ]
+        notes = row.get("notes", "").strip()
+        suffix = f" notes={notes}" if notes else ""
+        lines.append("- " + " | ".join(part for part in bits if part) + suffix)
+    return "\n".join(lines)
+
+
+def _decision_action(inputs) -> str:
+    if inputs is None:
+        return ""
+    first = format_decision(inputs).splitlines()[0]
+    return first.split(":", 1)[1].strip() if ":" in first else ""
+
+
+def _market_prices(symbol: str, market_dir: Path) -> list[tuple[date, float]]:
+    path = market_dir / f"{symbol.upper()}.csv"
+    if not path.exists():
+        return []
+    rows: list[tuple[date, float]] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            parsed_date = _parse_date(row.get("date", ""))
+            price = _row_price(row)
+            if parsed_date is not None and price is not None:
+                rows.append((parsed_date, price))
+    rows.sort(key=lambda item: item[0])
+    return rows
+
+
+def _row_price(row: dict[str, str]) -> float | None:
+    normalized = {key.strip().lower().replace(" ", "_").replace("-", "_"): key for key in row}
+    for candidate in ("adj_close", "adjusted_close", "close"):
+        column = normalized.get(candidate)
+        if column and row.get(column, "").strip():
+            return _float_or_none(row[column])
+    return None
+
+
+def _price_on_or_before(prices: list[tuple[date, float]], target: date) -> float | None:
+    prior = [price for row_date, price in prices if row_date <= target]
+    return prior[-1] if prior else None
+
+
+def _date_from_timestamp(value: str) -> date | None:
+    text = value.strip()
+    if not text:
+        return None
+    return _parse_date(text[:10])
+
+
+def _parse_date(value: str) -> date | None:
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        try:
+            return datetime.strptime(text[:10], "%m/%d/%Y").date()
+        except ValueError:
+            return None
+
+
+def _percent(value: str | None) -> float | None:
+    if value is None:
+        return None
+    text = value.strip()
+    try:
+        if text.endswith("%"):
+            return float(text[:-1]) / 100.0
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _number(value: float | int | None) -> str:
+    if value is None:
+        return ""
+    return f"{float(value):.6g}"
+
+
+def _float_or_none(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value.replace("$", "").replace(",", "").strip())
+    except ValueError:
+        return None
+
+
+def _money_text(value: str) -> str:
+    parsed = _float_or_none(value)
+    return "" if parsed is None else f"${parsed:,.2f}"
+
+
+def _percent_text(value: str) -> str:
+    parsed = _float_or_none(value)
+    return "" if parsed is None else f"{parsed:.1%}"

--- a/tests/test_portfolio_gui.py
+++ b/tests/test_portfolio_gui.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from trading_lab.portfolio.gui import apply_form_action, render_status_page
+from trading_lab.portfolio.outcomes import read_outcomes
 from trading_lab.portfolio.snapshots import read_snapshots
 from trading_lab.portfolio.state import read_account, read_open_orders, read_positions
 
@@ -99,6 +100,12 @@ def test_gui_contains_daily_decision_dark_css_dates_and_saved_account(tmp_path, 
     assert "Recent snapshots" in html
     assert 'action="/snapshot"' in html
     assert "Record snapshot" in html
+    assert "Decision outcomes" in html
+    assert "Recent outcomes" in html
+    assert 'action="/outcome/record"' in html
+    assert 'action="/outcome/update"' in html
+    assert "Record outcome" in html
+    assert "Update outcomes" in html
     assert "mini-scroll" in html
     assert "ACTION" not in html
     assert "HOLD" in html
@@ -275,6 +282,8 @@ def test_gui_apply_form_actions_edit_local_csvs(tmp_path: Path, monkeypatch):
     )
     assert apply_form_action("/order/clear", {"symbol": "TQQQ"})
     assert apply_form_action("/snapshot", {"risk_mode": "balanced", "notes": "gui"})
+    assert apply_form_action("/outcome/record", {"risk_mode": "balanced", "notes": "gui outcome"})
+    assert apply_form_action("/outcome/update", {})
 
     assert read_account().cash == 1000
     assert read_account().account_value == 5000
@@ -283,3 +292,6 @@ def test_gui_apply_form_actions_edit_local_csvs(tmp_path: Path, monkeypatch):
     rows = read_snapshots(tmp_path / "data" / "processed" / "portfolio" / "snapshots.csv")
     assert rows[-1]["risk_mode"] == "balanced"
     assert rows[-1]["notes"] == "gui"
+    outcomes = read_outcomes(tmp_path / "data" / "processed" / "portfolio" / "decision_outcomes.csv")
+    assert outcomes[-1]["risk_mode"] == "balanced"
+    assert outcomes[-1]["notes"] == "gui outcome"

--- a/tests/test_portfolio_outcomes.py
+++ b/tests/test_portfolio_outcomes.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from trading_lab.portfolio.outcomes import (
+    append_outcome,
+    build_outcome_row,
+    format_outcomes,
+    read_outcomes,
+    update_outcomes,
+)
+
+
+SUMMARY = """Date: 2026-05-04
+QQQ: 420.00
+TQQQ: 60.00
+Profile: default
+Active target mode: barrier_first_hit
+Active target column: TQQQ_hit_up_before_down_5d
+Suggested action: WAIT_FOR_PULLBACK
+Max TQQQ allocation: 5%
+Selected strategy eligible today: NO
+- NO: selected model probability 0.580 < threshold 0.65
+
+Suggested TQQQ ladder:
+- better_pullback: limit $58.20, allocation 1.2%, synthetic.
+"""
+
+
+def _write_outcome_fixture(tmp_path: Path, *, future_days: int = 10) -> tuple[Path, Path, Path, Path, Path]:
+    portfolio_dir = tmp_path / "data" / "raw" / "portfolio"
+    market_dir = tmp_path / "data" / "raw" / "market"
+    reports_dir = tmp_path / "data" / "reports"
+    portfolio_dir.mkdir(parents=True)
+    market_dir.mkdir(parents=True)
+    reports_dir.mkdir(parents=True)
+    positions = portfolio_dir / "positions.csv"
+    orders = portfolio_dir / "open_orders.csv"
+    account = portfolio_dir / "account.csv"
+    positions.write_text(
+        "symbol,quantity,notes,updated_at\nTQQQ,4,current_position,2026-05-04\n",
+        encoding="utf-8",
+    )
+    orders.write_text(
+        "symbol,side,type,quantity,limit_price,time_in_force,status,submitted_at,notes\n"
+        "TQQQ,buy,limit,10,58.00,GTC,placed,2026-04-29,current_open_order\n"
+        "TQQQ,sell,limit,4,68.50,GTC,placed,2026-04-29,current_open_order\n",
+        encoding="utf-8",
+    )
+    account.write_text(
+        "key,value,updated_at\ncash,1000,2026-05-04\naccount_value,5000,2026-05-04\n",
+        encoding="utf-8",
+    )
+    prices = ["date,close\n", "2026-05-04,60\n"]
+    for index in range(1, future_days + 1):
+        prices.append(f"2026-05-{4 + index:02d},{60 + index}\n")
+    (market_dir / "TQQQ.csv").write_text("".join(prices), encoding="utf-8")
+    (reports_dir / "daily_decision_summary.txt").write_text(SUMMARY, encoding="utf-8")
+    (reports_dir / "selected_model_latest_signal.csv").write_text(
+        "date,model,probability\n2026-05-04,demo,0.58\n",
+        encoding="utf-8",
+    )
+    return positions, orders, account, market_dir, reports_dir
+
+
+def test_record_outcome_writes_local_row_from_synthetic_files(tmp_path: Path):
+    positions, orders, account, market_dir, reports_dir = _write_outcome_fixture(tmp_path)
+    path = tmp_path / "data" / "processed" / "portfolio" / "decision_outcomes.csv"
+
+    result = append_outcome(
+        path=path,
+        risk_mode="balanced",
+        notes="unit",
+        reports_dir=reports_dir,
+        positions_path=positions,
+        open_orders_path=orders,
+        account_path=account,
+        market_dir=market_dir,
+        now=datetime(2026, 5, 4, 9, 30),
+    )
+
+    assert result.path == path
+    rows = read_outcomes(path, limit=10)
+    assert rows[-1]["risk_mode"] == "balanced"
+    assert rows[-1]["action"] == "HOLD"
+    assert rows[-1]["traded_symbol"] == "TQQQ"
+    assert rows[-1]["traded_price_at_decision"] == "60"
+    assert rows[-1]["model_probability"] == "0.58"
+    assert rows[-1]["active_target_mode"] == "barrier_first_hit"
+    assert rows[-1]["active_target_column"] == "TQQQ_hit_up_before_down_5d"
+    assert rows[-1]["suggested_report_action"] == "WAIT_FOR_PULLBACK"
+    assert rows[-1]["strategy_eligible_today"] == "NO"
+    assert rows[-1]["max_exposure"] == "250"
+    assert rows[-1]["current_exposure"] == "240"
+    assert rows[-1]["pending_buy_notional"] == "580"
+    assert rows[-1]["pending_sell_notional"] == "274"
+    assert rows[-1]["outcome_status"] == "PENDING"
+    assert "Cancel/reduce current pending TQQQ buys" in rows[-1]["suggested_order_summary"]
+    assert rows[-1]["notes"] == "unit"
+
+
+def test_outcome_appends_instead_of_overwriting(tmp_path: Path):
+    positions, orders, account, market_dir, reports_dir = _write_outcome_fixture(tmp_path)
+    path = tmp_path / "data" / "processed" / "portfolio" / "decision_outcomes.csv"
+
+    for note in ("first", "second"):
+        append_outcome(
+            path=path,
+            notes=note,
+            reports_dir=reports_dir,
+            positions_path=positions,
+            open_orders_path=orders,
+            account_path=account,
+            market_dir=market_dir,
+            now=datetime(2026, 5, 4, 9, 30),
+        )
+
+    assert [row["notes"] for row in read_outcomes(path, limit=10)] == ["first", "second"]
+
+
+def test_outcome_update_fills_future_prices_and_returns(tmp_path: Path):
+    positions, orders, account, market_dir, reports_dir = _write_outcome_fixture(tmp_path, future_days=10)
+    path = tmp_path / "data" / "processed" / "portfolio" / "decision_outcomes.csv"
+    append_outcome(
+        path=path,
+        reports_dir=reports_dir,
+        positions_path=positions,
+        open_orders_path=orders,
+        account_path=account,
+        market_dir=market_dir,
+        now=datetime(2026, 5, 4, 9, 30),
+    )
+
+    assert update_outcomes(path=path, market_dir=market_dir) == 1
+    row = read_outcomes(path, limit=1)[0]
+    assert row["future_price_1d"] == "61"
+    assert row["future_price_3d"] == "63"
+    assert row["future_price_5d"] == "65"
+    assert row["future_price_10d"] == "70"
+    assert row["return_1d"] == "0.0166667"
+    assert row["return_10d"] == "0.166667"
+    assert row["outcome_status"] == "UPDATED"
+
+
+def test_outcome_update_insufficient_future_data_remains_pendingish(tmp_path: Path):
+    positions, orders, account, market_dir, reports_dir = _write_outcome_fixture(tmp_path, future_days=3)
+    path = tmp_path / "data" / "processed" / "portfolio" / "decision_outcomes.csv"
+    append_outcome(
+        path=path,
+        reports_dir=reports_dir,
+        positions_path=positions,
+        open_orders_path=orders,
+        account_path=account,
+        market_dir=market_dir,
+        now=datetime(2026, 5, 4, 9, 30),
+    )
+
+    update_outcomes(path=path, market_dir=market_dir)
+    row = read_outcomes(path, limit=1)[0]
+    assert row["future_price_3d"] == "63"
+    assert row["future_price_5d"] == ""
+    assert row["outcome_status"] == "INSUFFICIENT_FUTURE_DATA"
+
+
+def test_outcome_missing_price_handled_cleanly(tmp_path: Path):
+    positions, orders, account, market_dir, reports_dir = _write_outcome_fixture(tmp_path)
+    path = tmp_path / "data" / "processed" / "portfolio" / "decision_outcomes.csv"
+    append_outcome(
+        path=path,
+        reports_dir=reports_dir,
+        positions_path=positions,
+        open_orders_path=orders,
+        account_path=account,
+        market_dir=market_dir,
+        now=datetime(2026, 5, 4, 9, 30),
+    )
+    (market_dir / "TQQQ.csv").unlink()
+
+    update_outcomes(path=path, market_dir=market_dir)
+    row = read_outcomes(path, limit=1)[0]
+
+    assert row["outcome_status"] == "PRICE_MISSING"
+    assert row["current_price"] == "60"
+
+
+def test_cli_outcome_commands_and_decide_record_do_not_run_workflow(tmp_path, monkeypatch, capsys):
+    _write_outcome_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    import trading_lab.cli.main as cli_main
+
+    def fail_run(command):
+        raise AssertionError(f"unexpected command run: {command}")
+
+    monkeypatch.setattr(cli_main, "_run", fail_run)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["tl", "portfolio", "outcome-record", "--risk-mode", "balanced", "--notes", "cli"],
+    )
+    cli_main.main()
+    assert "Recorded local-only decision outcome row" in capsys.readouterr().out
+
+    monkeypatch.setattr("sys.argv", ["tl", "portfolio", "outcomes", "--limit", "1"])
+    cli_main.main()
+    out = capsys.readouterr().out
+    assert "Recent decision outcomes:" in out
+    assert "notes=cli" in out
+
+    monkeypatch.setattr("sys.argv", ["tl", "portfolio", "outcome-update"])
+    cli_main.main()
+    assert "Updated" in capsys.readouterr().out
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["tl", "decide", "--risk-mode", "balanced", "--record-outcome", "--outcome-notes", "decide"],
+    )
+    cli_main.main()
+    out = capsys.readouterr().out
+    assert "ACTION:" in out
+    assert "Recorded local-only decision outcome row" in out
+    assert read_outcomes(tmp_path / "data" / "processed" / "portfolio" / "decision_outcomes.csv")[-1][
+        "notes"
+    ] == "decide"
+
+
+def test_top_level_outcome_aliases(tmp_path, monkeypatch, capsys):
+    _write_outcome_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    import trading_lab.cli.main as cli_main
+
+    monkeypatch.setattr("sys.argv", ["tl", "outcome", "record", "--notes", "alias"])
+    cli_main.main()
+    assert "Recorded local-only decision outcome row" in capsys.readouterr().out
+
+    monkeypatch.setattr("sys.argv", ["tl", "outcome", "list", "--limit", "1"])
+    cli_main.main()
+    assert "notes=alias" in capsys.readouterr().out
+
+    monkeypatch.setattr("sys.argv", ["tl", "outcome", "update"])
+    cli_main.main()
+    assert "Updated" in capsys.readouterr().out
+
+
+def test_format_outcomes_handles_empty_and_recent_rows():
+    assert format_outcomes([]) == "No local decision outcomes found."
+    text = format_outcomes(
+        [
+            {
+                "decision_timestamp": "2026-05-04T09:30:00",
+                "risk_mode": "balanced",
+                "action": "HOLD",
+                "traded_symbol": "TQQQ",
+                "traded_price_at_decision": "60",
+                "return_5d": "0.05",
+                "outcome_status": "UPDATED",
+                "notes": "x",
+            }
+        ]
+    )
+    assert "$60.00" in text
+    assert "5.0%" in text
+    assert "notes=x" in text


### PR DESCRIPTION
Adds local gitignored outcome tracking for tl decisions and suggested order ideas using local market data. Closes #20.